### PR TITLE
Added build_week_of_year and weeks_since_project_start

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,6 +15,14 @@
 			against? -->
   </parent>
 
+  <dependencies>
+    <dependency>
+      <groupId>joda-time</groupId>
+      <artifactId>joda-time</artifactId>
+      <version>2.0</version>
+    </dependency>
+  </dependencies>
+
   <licenses>
     <license>
       <name>MIT license</name>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <groupId>org.jvnet.hudson.tools</groupId>
   <artifactId>versionnumber</artifactId>
   <packaging>hpi</packaging>
-  <version>1.4.1</version>
+  <version>1.5-SNAPSHOT</version>
   <name>Version Number Plug-In</name>
   <url>https://wiki.jenkins-ci.org/display/JENKINS/Version+Number+Plugin</url>
   

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <groupId>org.jvnet.hudson.tools</groupId>
   <artifactId>versionnumber</artifactId>
   <packaging>hpi</packaging>
-  <version>1.5-SNAPSHOT</version>
+  <version>1.4.1</version>
   <name>Version Number Plug-In</name>
   <url>https://wiki.jenkins-ci.org/display/JENKINS/Version+Number+Plugin</url>
   

--- a/src/main/java/org/jvnet/hudson/tools/versionnumber/VersionNumberBuilder.java
+++ b/src/main/java/org/jvnet/hudson/tools/versionnumber/VersionNumberBuilder.java
@@ -26,6 +26,9 @@ import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.QueryParameter;
 import org.kohsuke.stapler.StaplerRequest;
 
+import org.joda.time.DateTime;
+import org.joda.time.Days;
+
 /**
  * Sample {@link Builder}.
  *
@@ -327,6 +330,10 @@ public class VersionNumberBuilder extends BuildWrapper {
                     replaceValue = sizeTo(Integer.toString(info.getBuildsThisYear() - 1), argumentString.length());
                 } else if ("BUILDS_ALL_TIME_Z".equals(expressionKey)) {
                     replaceValue = sizeTo(Integer.toString(info.getBuildsAllTime() - 1), argumentString.length());
+                } else if ("WEEKS_SINCE_PROJECT_START".equals(expressionKey)) {
+                    int daysSinceStart = Days.daysBetween(new DateTime(projectStartDate), new DateTime(buildDate.getTime())).getDays();
+                    int weeksSinceStart = daysSinceStart / 7;
+                    replaceValue = sizeTo(Integer.toString(weeksSinceStart), argumentString.length());
                 } else if ("MONTHS_SINCE_PROJECT_START".equals(expressionKey)) {
                     Calendar projectStartCal = Calendar.getInstance();
                     projectStartCal.setTime(projectStartDate);

--- a/src/main/webapp/help-versionNumberFormatString.html
+++ b/src/main/webapp/help-versionNumberFormatString.html
@@ -91,6 +91,14 @@
 			</tr>
 			<tr>
 				<td>
+					WEEKS_SINCE_PROJECT_START
+				</td>
+				<td>
+					The number of calendar weeks that have elapsed since the project start date.
+				</td>
+			</tr>
+			<tr>
+				<td>
 					MONTHS_SINCE_PROJECT_START
 				</td>
 				<td>


### PR DESCRIPTION
Two new version number string options have been implemented:
- BUILD_WEEK_OF_YEAR
- WEEKS_SINCE_PROJECT_START

Note: the first one was pulled from gommo/Hudson-VersionNumber-Plugin.
