### PR TITLE
Allow reusing the same formatted build string.

### DIFF
--- a/src/main/java/org/jvnet/hudson/tools/versionnumber/VersionNumberAction.java
+++ b/src/main/java/org/jvnet/hudson/tools/versionnumber/VersionNumberAction.java
@@ -16,11 +16,15 @@ public class VersionNumberAction implements Action {
     public VersionNumberBuildInfo getInfo() {
         return info;
     }
-    
+
+    public String getVersionNumber() {
+	return this.versionNumber;
+    }
+
     public String getDisplayName() {
         return "Version " + this.versionNumber;
     }
-    
+
     public String getIconFileName() {
         return ICON;
     }

--- a/src/main/resources/org/jvnet/hudson/tools/versionnumber/VersionNumberBuilder/config.jelly
+++ b/src/main/resources/org/jvnet/hudson/tools/versionnumber/VersionNumberBuilder/config.jelly
@@ -5,6 +5,9 @@
   <f:entry title="Version Number Format String" help="/plugin/versionnumber/help-versionNumberFormatString.html">
     <f:textbox field="versionNumberString" />
   </f:entry>
+  <f:entry title="Prefix Variable" help="/plugin/versionnumber/help-environmentPrefixVariable.html">
+    <f:textbox field="environmentPrefixVariable" />
+  </f:entry>
   <f:entry title="Failed Builds" help="/plugin/versionnumber/help-reuseVersionNumbers.html">
     <f:checkbox name="skipFailedBuilds" checked="${instance.skipFailedBuilds}" />
     	Don't increment builds today/ this month/ this year/ all time after a failed build.

--- a/src/main/webapp/help-environmentPrefixVariable.html
+++ b/src/main/webapp/help-environmentPrefixVariable.html
@@ -1,0 +1,5 @@
+<div>
+	<p>
+		The prefix variable name is the environment variable specified here to allow using the same build numbers for all the release tags.
+	</p>
+</div>

--- a/src/test/java/org/jvnet/hudson/tools/versionnumber/VersionNumberBuilderTest.java
+++ b/src/test/java/org/jvnet/hudson/tools/versionnumber/VersionNumberBuilderTest.java
@@ -19,7 +19,7 @@ public class VersionNumberBuilderTest extends HudsonTestCase {
 	public void testTwoBuilds() throws Exception {
 		FreeStyleProject job = createFreeStyleProject("versionNumberJob");
 		VersionNumberBuilder versionNumberBuilder = new VersionNumberBuilder(
-				"1.0.${BUILDS_ALL_TIME}", null, null, null, null, null, null, false);
+				"1.0.${BUILDS_ALL_TIME}", null, null, null, null, null, null, null, false);
 		job.getBuildWrappersList().add(versionNumberBuilder);
 		FreeStyleBuild build = buildAndAssertSuccess(job);
 		build = buildAndAssertSuccess(job);
@@ -30,7 +30,7 @@ public class VersionNumberBuilderTest extends HudsonTestCase {
 	public void testFailureEarlyDoesNotResetVersionNumber() throws Exception {
 		FreeStyleProject job = createFreeStyleProject("versionNumberJob");
 		VersionNumberBuilder versionNumberBuilder = new VersionNumberBuilder(
-				"1.0.${BUILDS_ALL_TIME}", null, null, null, null, null, null, false);
+				"1.0.${BUILDS_ALL_TIME}", null, null, null, null, null, null, null, false);
 		job.getBuildWrappersList().add(versionNumberBuilder);
 		buildAndAssertSuccess(job);
 		buildAndAssertSuccess(job);
@@ -50,7 +50,7 @@ public class VersionNumberBuilderTest extends HudsonTestCase {
 	public void testUseAsBuildDisplayName() throws Exception {
 		FreeStyleProject job = createFreeStyleProject("versionNumberJob");
 		VersionNumberBuilder versionNumberBuilder = new VersionNumberBuilder(
-				"1.0.${BUILDS_ALL_TIME}", null, null, null, null, null, null, false, true);
+				"1.0.${BUILDS_ALL_TIME}", null, null, null, null, null, null, null, false, true);
 		job.getBuildWrappersList().add(versionNumberBuilder);
 		FreeStyleBuild build = buildAndAssertSuccess(job);
 		assertEquals("1.0.1", build.getDisplayName());


### PR DESCRIPTION
This allows to reuse the same build number for different versions
using a environment variable to specify the build tag.

Example (before):
   v1.00-b001
   v2.00-b002
   v1.00-b003

Example (after):
   v1.00-b001
   v2.00-b001
   v1.00-b002