### PR TITLE
Add complementary BUILD_WEEK and BUILDS_THIS_WEEK

### DIFF
--- a/src/main/java/org/jvnet/hudson/tools/versionnumber/VersionNumberBuildInfo.java
+++ b/src/main/java/org/jvnet/hudson/tools/versionnumber/VersionNumberBuildInfo.java
@@ -2,14 +2,16 @@ package org.jvnet.hudson.tools.versionnumber;
 
 public class VersionNumberBuildInfo {
     private int buildsToday;
+    private int buildsThisWeek;
     private int buildsThisMonth;
     private int buildsThisYear;
     private int buildsAllTime;
     
-    public VersionNumberBuildInfo(int buildsToday, int buildsThisMonth,
+    public VersionNumberBuildInfo(int buildsToday, int buildsThisWeek, int buildsThisMonth,
                                   int buildsThisYear, int buildsAllTime) {
         super();
         this.buildsToday = buildsToday;
+        this.buildsThisWeek = buildsThisWeek;
         this.buildsThisMonth = buildsThisMonth;
         this.buildsThisYear = buildsThisYear;
         this.buildsAllTime = buildsAllTime;
@@ -17,6 +19,9 @@ public class VersionNumberBuildInfo {
     
     public int getBuildsToday() {
         return buildsToday;
+    }
+    public int getBuildsThisWeek() {
+        return buildsThisWeek;
     }
     public int getBuildsThisMonth() {
         return buildsThisMonth;
@@ -27,4 +32,5 @@ public class VersionNumberBuildInfo {
     public int getBuildsAllTime() {
         return buildsAllTime;
     }
+
 }

--- a/src/main/resources/org/jvnet/hudson/tools/versionnumber/VersionNumberBuilder/config.jelly
+++ b/src/main/resources/org/jvnet/hudson/tools/versionnumber/VersionNumberBuilder/config.jelly
@@ -22,6 +22,9 @@
   <f:entry title="Number of builds today" help="/plugin/versionnumber/help-overrideNumbers.html">
     <f:textbox field="buildsToday" />
   </f:entry>
+  <f:entry title="Number of builds this week" help="/plugin/versionnumber/help-overrideNumbers.html">
+    <f:textbox field="buildsThisWeek" />
+  </f:entry>
   <f:entry title="Number of builds this month" help="/plugin/versionnumber/help-overrideNumbers.html">
     <f:textbox field="buildsThisMonth" />
   </f:entry>

--- a/src/main/webapp/help-versionNumberFormatString.html
+++ b/src/main/webapp/help-versionNumberFormatString.html
@@ -35,6 +35,14 @@
 			</tr>
 			<tr>
 				<td>
+					BUILD_WEEK
+				</td>
+				<td>
+					The week of the year of the build.
+				</td>
+			</tr>
+			<tr>
+				<td>
 					BUILD_MONTH
 				</td>
 				<td>
@@ -55,6 +63,14 @@
 				</td>
 				<td>
 					The number of builds done on this calendar date.
+				</td>
+			</tr>
+			<tr>
+				<td>
+					BUILDS_THIS_WEEK
+				</td>
+				<td>
+					The number of builds done in this calendar week.
 				</td>
 			</tr>
 			<tr>

--- a/src/test/java/org/jvnet/hudson/tools/versionnumber/VersionNumberBuilderTest.java
+++ b/src/test/java/org/jvnet/hudson/tools/versionnumber/VersionNumberBuilderTest.java
@@ -24,10 +24,10 @@ public class VersionNumberBuilderTest extends HudsonTestCase {
         FreeStyleBuild build;
         
         VersionNumberBuilder versionNumberBuilder = new VersionNumberBuilder(
-                "1.0.${BUILDS_ALL_TIME}", null, null, "VERSION_PREFIX", null, null, null, null, false);
+                "1.0.${BUILDS_ALL_TIME}", null, null, "VERSION_PREFIX", null, null, null, null, null, false);
         
         VersionNumberBuilder versionNumberBuilderWithPrefix = new VersionNumberBuilder(
-                "${VERSION_PREFIX}${BUILDS_ALL_TIME}", null, null, "VERSION_PREFIX", null, null, null, null, false);
+                "${VERSION_PREFIX}${BUILDS_ALL_TIME}", null, null, "VERSION_PREFIX", null, null, null, null, null, false);
         
         job.getBuildWrappersList().add(versionNumberBuilder);
         
@@ -72,7 +72,7 @@ public class VersionNumberBuilderTest extends HudsonTestCase {
     public void testTwoBuilds() throws Exception {
         FreeStyleProject job = createFreeStyleProject("versionNumberJob");
         VersionNumberBuilder versionNumberBuilder = new VersionNumberBuilder(
-                "1.0.${BUILDS_ALL_TIME}", null, null, null, null, null, null, null, false);
+                "1.0.${BUILDS_ALL_TIME}", null, null, null, null, null, null, null, null, false);
         job.getBuildWrappersList().add(versionNumberBuilder);
         FreeStyleBuild build = buildAndAssertSuccess(job);
         build = buildAndAssertSuccess(job);
@@ -83,7 +83,7 @@ public class VersionNumberBuilderTest extends HudsonTestCase {
     public void testFailureEarlyDoesNotResetVersionNumber() throws Exception {
         FreeStyleProject job = createFreeStyleProject("versionNumberJob");
         VersionNumberBuilder versionNumberBuilder = new VersionNumberBuilder(
-                "1.0.${BUILDS_ALL_TIME}", null, null, null, null, null, null, null, false);
+                "1.0.${BUILDS_ALL_TIME}", null, null, null, null, null, null, null, null, false);
         job.getBuildWrappersList().add(versionNumberBuilder);
         buildAndAssertSuccess(job);
         buildAndAssertSuccess(job);
@@ -103,7 +103,7 @@ public class VersionNumberBuilderTest extends HudsonTestCase {
     public void testUseAsBuildDisplayName() throws Exception {
         FreeStyleProject job = createFreeStyleProject("versionNumberJob");
         VersionNumberBuilder versionNumberBuilder = new VersionNumberBuilder(
-                "1.0.${BUILDS_ALL_TIME}", null, null, null, null, null, null, null, false, true);
+                "1.0.${BUILDS_ALL_TIME}", null, null, null, null, null, null, null, null, false, true);
         job.getBuildWrappersList().add(versionNumberBuilder);
         FreeStyleBuild build = buildAndAssertSuccess(job);
         assertEquals("1.0.1", build.getDisplayName());
@@ -114,12 +114,13 @@ public class VersionNumberBuilderTest extends HudsonTestCase {
     public void testValueFromEnvironmentVariable() throws Exception {
         FreeStyleProject job = createFreeStyleProject("versionNumberJob");
         VersionNumberBuilder versionNumberBuilder = new VersionNumberBuilder(
-                "${BUILDS_TODAY}.${BUILDS_THIS_MONTH}.${BUILDS_THIS_YEAR}.${BUILDS_ALL_TIME}",
-                null, null, null, "${ENVVAL_OF_TODAY}", "${ENVVAL_OF_THIS_MONTH}", "${ENVVAL_OF_THIS_YEAR}", "${ENVVAL_OF_ALL_TIME}", false, true);
+                "${BUILDS_TODAY}.${BUILDS_THIS_WEEK}.${BUILDS_THIS_MONTH}.${BUILDS_THIS_YEAR}.${BUILDS_ALL_TIME}",
+                null, null, null, "${ENVVAL_OF_TODAY}", "${ENVVAL_OF_THIS_WEEK}", "${ENVVAL_OF_THIS_MONTH}", "${ENVVAL_OF_THIS_YEAR}", "${ENVVAL_OF_ALL_TIME}", false, true);
         
         EnvironmentVariablesNodeProperty prop = new EnvironmentVariablesNodeProperty();
         EnvVars envVars = prop.getEnvVars();
         envVars.put("ENVVAL_OF_TODAY", "-10");           // Invalid (negative) value
+        envVars.put("ENVVAL_OF_THIS_WEEK", "2.0");       // Invalid (float number) value
         envVars.put("ENVVAL_OF_THIS_MONTH", "Invalid");  // Invalid (non-number) value
         //envVars.put("ENVVAL_OF_THIS_YEAR", "");        // No variable
         envVars.put("ENVVAL_OF_ALL_TIME", "20");         // Normal value
@@ -127,7 +128,7 @@ public class VersionNumberBuilderTest extends HudsonTestCase {
         
         job.getBuildWrappersList().add(versionNumberBuilder);
         FreeStyleBuild build = buildAndAssertSuccess(job);
-        assertEquals("1.1.1.20", build.getDisplayName());
+        assertEquals("1.1.1.1.20", build.getDisplayName());
     }
     
     private void assertBuildsAllTime(int expected, AbstractBuild build) {


### PR DESCRIPTION
Useful for projects that have constant weekly increments. Allows to use build numbering scheme that have current week of the year number and consecutive number, e.g.: "wk10.1, wk10.2, wk10.3, wk11.1, wk11.2, ...". This is supplementary to day/month/year periods.