### PR TITLE
work around NPE in JDKInstaller

### DIFF
--- a/src/main/java/org/jvnet/hudson/tools/versionnumber/VersionNumberBuilder.java
+++ b/src/main/java/org/jvnet/hudson/tools/versionnumber/VersionNumberBuilder.java
@@ -173,9 +173,7 @@ public class VersionNumberBuilder extends BuildWrapper {
                 EnvVars env = build.getEnvironment(null);
                 
                 envPrefix = env.get(this.environmentPrefixVariable);
-            } catch (IOException e) {
-                envPrefix = null;
-            } catch (InterruptedException e) {
+            } catch (Exception e) {
                 envPrefix = null;
             }
         } else {


### PR DESCRIPTION
when running a job with the VersionNumber plugin active on any other node than master I get this stacktrace:

```
java.lang.NullPointerException
    at hudson.tools.JDKInstaller.performInstallation(JDKInstaller.java:119)
    at hudson.tools.InstallerTranslator.getToolHome(InstallerTranslator.java:68)
    at hudson.tools.ToolLocationNodeProperty.getToolHome(ToolLocationNodeProperty.java:107)
    at hudson.tools.ToolInstallation.translateFor(ToolInstallation.java:205)
    at hudson.model.JDK.forNode(JDK.java:130)
    at hudson.model.AbstractProject.getEnvironment(AbstractProject.java:351)
    at hudson.model.Run.getEnvironment(Run.java:2234)
    at hudson.model.AbstractBuild.getEnvironment(AbstractBuild.java:917)
    at org.jvnet.hudson.tools.versionnumber.VersionNumberBuilder.getPreviousBuildWithVersionNumber(VersionNumberBuilder.java:173)
    at org.jvnet.hudson.tools.versionnumber.VersionNumberBuilder.incBuild(VersionNumberBuilder.java:211)
    at org.jvnet.hudson.tools.versionnumber.VersionNumberBuilder.setUp(VersionNumberBuilder.java:398)
    at hudson.model.Build$BuildExecution.doRun(Build.java:154)
    at hudson.model.AbstractBuild$AbstractBuildExecution.run(AbstractBuild.java:536)
    at hudson.model.Run.execute(Run.java:1741)
    at hudson.model.FreeStyleBuild.run(FreeStyleBuild.java:43)
    at hudson.model.ResourceController.execute(ResourceController.java:98)
    at hudson.model.Executor.run(Executor.java:374)
```
