### PR TITLE
[FIXED JENKINS-29134]

### DIFF
--- a/src/main/webapp/help-overrideNumbers.html
+++ b/src/main/webapp/help-overrideNumbers.html
@@ -1,6 +1,19 @@
 <div>
-	If a number is specified here, it will override the number tracked from build to build and the next build
-	will use this number instead.  If left blank, it will increment the number from the previous build if necessary,
-	and use that.  If no previous build used the Version Number Plugin, then this defaults to 1.  Negative numbers
-	are not allowed.
+	<p>
+	If left blank, the next build will increment the number from the previous build if necessary,
+	and use that.  If no previous build used the Version Number Plugin, then this defaults to 1.
+	</p>
+	<p>
+	If a number is specified here, it will override the number tracked from build to build and the
+	next build will use this number instead.  Negative numbers are allowed.
+	</p>
+	<p>
+	If an environment-variable is specified here, its value will be retrieved during the next build
+	and will be used as number. However, if that environment-variable is not set or its value is not
+	convertible into a number, the standard behavior will kick in as if this field was left blank.
+	(That means, the number from the previous build will be incremented and used.)
+	</p>
+	<p>
+	Other values will be ignored as if left blank.
+	</p>
 </div>


### PR DESCRIPTION
Added support for automatically overriding the values of "BUILDS_TODAY",
"BUILDS_THIS_MONTH", "BUILDS_THIS_YEAR" and "BUILDS_ALL_TIME" with
values taken from environment-variables.

Instead of just providing a simple number in the form-fields of the
job's plugin-configuration which overrides the value for the next build,
one can now provide an environment-variable whose value will be
extracted and used instead during the next builds.
If it is not set or its value is not convertible to an integer, the
value of the previous build will be taken instead and increased by one.

Additonally, negative numbers are allowed now. (However, even they will
always only be increased and never decreased!)

Signed-off-by: Deniz Bahadir <dbahadir@benocs.com>