### PR TITLE
print stacktrace in console log

### DIFF
--- a/src/main/java/org/jvnet/hudson/tools/versionnumber/VersionNumberBuilder.java
+++ b/src/main/java/org/jvnet/hudson/tools/versionnumber/VersionNumberBuilder.java
@@ -507,15 +507,13 @@ public class VersionNumberBuilder extends BuildWrapper {
                 build.setDisplayName(formattedVersionNumber);
             }
         } catch (IOException e) {
-            // TODO Auto-generated catch block
-            listener.error(e.toString());
+            e.printStackTrace(listener.error(e.toString()));
             build.setResult(Result.FAILURE);
         } catch (InterruptedException e) {
-            // TODO Auto-generated catch block
-            listener.error(e.toString());
+            e.printStackTrace(listener.error(e.toString()));
             build.setResult(Result.FAILURE);
         } catch (Exception e) {
-            listener.error(e.toString());
+            e.printStackTrace(listener.error(e.toString()));
             build.setResult(Result.FAILURE);
         }
         final String finalVersionNumber = formattedVersionNumber;


### PR DESCRIPTION
Print stacktrace of exceptions in console log in order to chase [JENKINS-30224](https://issues.jenkins-ci.org/browse/JENKINS-30224)