### PR TITLE
Adding functionality to limit the number of characters from a variable

### DIFF
--- a/src/main/java/org/jvnet/hudson/tools/versionnumber/VersionNumberBuilder.java
+++ b/src/main/java/org/jvnet/hudson/tools/versionnumber/VersionNumberBuilder.java
@@ -523,7 +523,7 @@ public class VersionNumberBuilder extends BuildWrapper {
                                 // reused this line from above
                                 String fmtString = argumentString.substring(argumentString.indexOf('"') + 1, argumentString.indexOf('"', argumentString.indexOf('"') + 1));
                                 // make sure the number is a positive or negative whole number
-                                if (fmtString.matches("^(-?)\\d*$")) {
+                                if (fmtString.matches("^(\\+|-)?\\d*$")) {
                                     Integer fmtInt = Integer.parseInt(fmtString);
                                     // if it's not smaller than the length of the value, we will use the whole value
                                     if (Math.abs(fmtInt.intValue()) < replaceValue.length()) {

--- a/src/main/java/org/jvnet/hudson/tools/versionnumber/VersionNumberBuilder.java
+++ b/src/main/java/org/jvnet/hudson/tools/versionnumber/VersionNumberBuilder.java
@@ -516,6 +516,25 @@ public class VersionNumberBuilder extends BuildWrapper {
                     for (String enVarKey : enVars.keySet()) {
                         if (enVarKey.equals(expressionKey)) {
                             replaceValue = enVars.get(enVarKey);
+                            // we will use the below lines to limit the number of character we want to 
+                            // use from the front or the back of the environment variable
+                            // make sure there is an argument string and that it has two quotes
+                            if (!"".equals(argumentString) && argumentString.indexOf("\"") != -1 && argumentString.indexOf("\"") != argumentString.lastIndexOf("\"")) {
+                                // reused this line from above
+                                String fmtString = argumentString.substring(argumentString.indexOf('"') + 1, argumentString.indexOf('"', argumentString.indexOf('"') + 1));
+                                // make sure the number is a positive or negative whole number
+                                if (fmtString.matches("^(-?)\\d*$")) {
+                                    Integer fmtInt = Integer.parseInt(fmtString);
+                                    // if it's not smaller than the length of the value, we will use the whole value
+                                    if (Math.abs(fmtInt.intValue()) < replaceValue.length()) {
+                                        if (fmtInt > 0) {
+                                            replaceValue = replaceValue.substring(0,fmtInt);
+                                        } else if (fmtInt < 0) {
+                                            replaceValue = replaceValue.substring(replaceValue.length()+fmtInt);
+                                        }
+                                    }
+                                }
+                            }
                         }
                     }
                 }

--- a/src/main/resources/index.jelly
+++ b/src/main/resources/index.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <!--
   This view is used to render the plugin list page.
 

--- a/src/main/resources/org/jvnet/hudson/tools/versionnumber/VersionNumberBuilder/config.jelly
+++ b/src/main/resources/org/jvnet/hudson/tools/versionnumber/VersionNumberBuilder/config.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <f:entry title="Environment Variable Name" help="/plugin/versionnumber/help-environmentVariableName.html">
     <f:textbox field="environmentVariableName" />

--- a/src/main/webapp/help-versionNumberFormatString.html
+++ b/src/main/webapp/help-versionNumberFormatString.html
@@ -10,10 +10,17 @@
 		Any variable not recognized in the table below will be replaced by an environment variable of the same name.
 		So to use the hudson build ID, stored in the environment variable BUILD_ID, you'd just use ${BUILD_ID}.
 		If no environment variable of the appropriate name can be found, the expression will just be replaced with
-		an empty string.
+		an empty string. 
 	</p>
 	<p>
-		
+		To limit the size of a variable not recognized in the table below, you can do so in the form of 
+		${variable_name, "N"} where N is a positive or negative whole number less than the amount of characters
+		in the variable. N can be in the form of "+N", "-N", or "N" where a positive number takes the first "N" 
+		characters from the variable and a negative number takes the last "N" characters from a variable. For 
+		example, to split up SVN_REVISION where SVN_REVISION is 123456, ${SVN_REVISION, "2"}.${SVN_REVISION, "-4"}
+		would return 12.3456.
+	</p>
+	<p>
 		<table>
 			<tr>
 			    <td>

--- a/src/test/java/org/jvnet/hudson/tools/versionnumber/VersionNumberBuilderTest.java
+++ b/src/test/java/org/jvnet/hudson/tools/versionnumber/VersionNumberBuilderTest.java
@@ -131,6 +131,24 @@ public class VersionNumberBuilderTest extends HudsonTestCase {
         assertEquals("1.1.1.1.20", build.getDisplayName());
     }
     
+    public void testSubstringFromEnvironmentVariable() throws Exception {
+        FreeStyleProject job = createFreeStyleProject("versionNumberJob");
+        VersionNumberBuilder versionNumberBuilder = new VersionNumberBuilder(
+                "${ENVVAL_TESTING, \"+3\"}.${ENVVAL_TESTING, \"2\"}.${ENVVAL_TESTING, \"-3\"}" + 
+                ".${ENVVAL_TESTING, \"5\"}.${ENVVAL_TESTING, \"+5\"}.${ENVVAL_TESTING, \"-5\"}" +
+                ".${ENVVAL_TESTING, \"0\"}.${ENVVAL_TESTING, \"1.5\"}.${ENVVAL_TESTING, \"test\"}", 
+                null, "${ENVVAL_TESTING}", null, null, null, null, null, null, false, true);
+        // tried 
+        EnvironmentVariablesNodeProperty prop = new EnvironmentVariablesNodeProperty();
+        EnvVars envVars = prop.getEnvVars();
+        envVars.put("ENVVAL_TESTING", "1234");
+        super.hudson.getGlobalNodeProperties().add(prop);
+        
+        job.getBuildWrappersList().add(versionNumberBuilder);
+        FreeStyleBuild build = buildAndAssertSuccess(job);
+        assertEquals("123.12.234.1234.1234.1234.1234.1234.1234", build.getDisplayName());
+    }
+    
     private void assertBuildsAllTime(int expected, AbstractBuild build) {
         VersionNumberAction versionNumberAction = build
                 .getAction(VersionNumberAction.class);


### PR DESCRIPTION
(anything else with substring)  Any other argument in the following format ${ARGUMENT, "n"} or ${ARGUMENT, "-n"} where ARGUMENT is your environment variable and n is a whole number. This can be used to limit the size of the environment variable you are using, taking the first "n" characters or the last "-n" characters from the variable. 
