### PR TITLE
add option to use UTC-formatted time when using BUILD_DATE_FORMATTED

### DIFF
--- a/src/main/resources/org/jvnet/hudson/tools/versionnumber/VersionNumberBuilder/config.jelly
+++ b/src/main/resources/org/jvnet/hudson/tools/versionnumber/VersionNumberBuilder/config.jelly
@@ -16,6 +16,10 @@
     <f:checkbox name="useAsBuildDisplayName" checked="${instance.useAsBuildDisplayName}" />
         Use the formatted version number for build display name.
   </f:entry>
+  <f:entry title="Format Use UTC Time Zone" help="/plugin/versionnumber/help-environmentFormatTimeInUtc.html">
+    <f:checkbox name="formatTimeInUtc" checked="${instance.formatTimeInUtc}" />
+        When using BUILD_DATE_FORMATTED, the output will use UTC time.
+  </f:entry>
   <f:entry title="Project Start Date" help="/plugin/versionnumber/help-projectStartDate.html">
     <f:textbox field="projectStartDate" />
   </f:entry>

--- a/src/main/webapp/help-environmentFormatTimeInUtc.html
+++ b/src/main/webapp/help-environmentFormatTimeInUtc.html
@@ -1,0 +1,7 @@
+<div>
+	<p>
+		When using BUILD_DATE_FORMATTED, the date will be formatted using the UTC time zone.  This is desriable if
+		using a timestamp as build identifier since it removes the possibility of a subsequent build having an earlier
+		build id due to daylight savings time.
+	</p>
+</div>


### PR DESCRIPTION
Eliminates potential non-increasing build numbers when using BUILD_DATE_FORMATTED caused by daylight savings time
