### PR TITLE
Pipeline support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>1.576</version> <!-- which version of Jenkins is this plugin built 
+    <version>1.609.1</version> <!-- which version of Jenkins is this plugin built
 			against? -->
   </parent>
 
@@ -69,6 +69,34 @@
             <url>http://repo.jenkins-ci.org/public/</url>
         </pluginRepository>
     </pluginRepositories>
+
+	<dependencies>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins.workflow</groupId>
+            <artifactId>workflow-api</artifactId>
+            <version>1.15</version>
+        </dependency>
+		<!-- Testing scope -->
+		<dependency>
+			<groupId>org.jenkins-ci.plugins.workflow</groupId>
+			<artifactId>workflow-aggregator</artifactId>
+			<version>1.14</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.jenkins-ci.plugins.workflow</groupId>
+			<artifactId>workflow-support</artifactId>
+			<version>1.14</version>
+			<classifier>tests</classifier>
+			<scope>test</scope>
+		</dependency>
+		<dependency> <!-- Required by workflow-cps-global-lib (transitive of git-server) -->
+			<groupId>org.jenkins-ci.modules</groupId>
+			<artifactId>sshd</artifactId>
+			<version>1.6</version>
+			<scope>test</scope>
+		</dependency>
+    </dependencies>
 </project>  
   
 

--- a/src/main/java/org/jvnet/hudson/tools/versionnumber/VersionNumberCommon.java
+++ b/src/main/java/org/jvnet/hudson/tools/versionnumber/VersionNumberCommon.java
@@ -1,0 +1,245 @@
+package org.jvnet.hudson.tools.versionnumber;
+
+import hudson.Extension;
+import hudson.EnvVars;
+import hudson.Launcher;
+import hudson.model.BuildListener;
+import hudson.model.Result;
+import hudson.model.AbstractBuild;
+import hudson.model.AbstractProject;
+import hudson.model.Run;
+import hudson.tasks.BuildWrapper;
+import hudson.tasks.BuildWrapperDescriptor;
+import hudson.tasks.Builder;
+import hudson.util.FormValidation;
+
+import java.io.IOException;
+import java.io.PrintStream;
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
+import java.util.Calendar;
+import java.util.Date;
+import java.util.Map;
+import java.util.logging.Logger;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import net.sf.json.JSONObject;
+
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.QueryParameter;
+import org.kohsuke.stapler.StaplerRequest;
+
+/**
+ * Common methods used by freestyle and pipeline jobs.
+ */
+public class VersionNumberCommon {
+    
+    private static final DateFormat defaultDateFormat = new SimpleDateFormat("yyyy-MM-dd");
+    
+    public static VersionNumberBuildInfo incBuild(Run build, Run prevBuild, boolean skipFailedBuilds) {
+        int buildsToday = 1;
+        int buildsThisWeek = 1;
+        int buildsThisMonth = 1;
+        int buildsThisYear = 1;
+        int buildsAllTime = 1;
+        // this is what we add to the previous version number to get builds today / this week / this month / this year / all time
+        int buildInc = 1;
+        
+        if (prevBuild != null) {
+            // if we're skipping version numbers on failed builds and the last build failed...
+            if (skipFailedBuilds && !prevBuild.getResult().equals(Result.SUCCESS)) {
+                // don't increment
+                buildInc = 0;
+            }
+            // get the current build date and the previous build date
+            Calendar curCal = build.getTimestamp();
+            Calendar todayCal = prevBuild.getTimestamp();
+            
+            // get the previous build version number information
+            VersionNumberAction prevAction = (VersionNumberAction)prevBuild.getAction(VersionNumberAction.class);
+            VersionNumberBuildInfo info = prevAction.getInfo();
+
+            // increment builds per day
+            if (curCal.get(Calendar.DAY_OF_MONTH) == todayCal
+                    .get(Calendar.DAY_OF_MONTH)
+                    && curCal.get(Calendar.MONTH) == todayCal
+                            .get(Calendar.MONTH)
+                    && curCal.get(Calendar.YEAR) == todayCal.get(Calendar.YEAR)) {
+                buildsToday = info.getBuildsToday() + buildInc;
+            } else {
+                buildsToday = 1;
+            }
+
+            // increment builds per week
+            if (curCal.get(Calendar.WEEK_OF_YEAR) == todayCal.get(Calendar.WEEK_OF_YEAR)
+                    && curCal.get(Calendar.YEAR) == todayCal.get(Calendar.YEAR)) {
+                buildsThisWeek = info.getBuildsThisWeek() + buildInc;
+            } else {
+                buildsThisWeek = 1;
+            }
+
+            // increment builds per month
+            if (curCal.get(Calendar.MONTH) == todayCal.get(Calendar.MONTH)
+                    && curCal.get(Calendar.YEAR) == todayCal.get(Calendar.YEAR)) {
+                buildsThisMonth = info.getBuildsThisMonth() + buildInc;
+            } else {
+                buildsThisMonth = 1;
+            }
+
+            // increment builds per year
+            if (curCal.get(Calendar.YEAR) == todayCal.get(Calendar.YEAR)) {
+                buildsThisYear = info.getBuildsThisYear() + buildInc;
+            } else {
+                buildsThisYear = 1;
+            }
+
+            // increment total builds
+            buildsAllTime = info.getBuildsAllTime() + buildInc;
+        }
+        
+        return new VersionNumberBuildInfo(buildsToday, buildsThisWeek, buildsThisMonth, buildsThisYear, buildsAllTime);
+    }
+    
+    public static Run getPreviousBuildWithVersionNumber(Run build, String envPrefix) {        
+        // a build that fails early will not have a VersionNumberAction attached
+        Run prevBuild = build.getPreviousBuild();
+        
+        while (prevBuild != null) {
+            VersionNumberAction prevAction = (VersionNumberAction)prevBuild.getAction(VersionNumberAction.class);
+            
+            if (prevAction != null) {
+                if (envPrefix != null) {
+                    String version = prevAction.getVersionNumber();
+    
+                    if (version.startsWith(envPrefix)) {
+                        return prevBuild;
+                    }
+                } else {
+                    return prevBuild;
+                }
+            }
+            
+            prevBuild = prevBuild.getPreviousBuild();
+        }
+        
+        return null;
+    }
+    
+    public static Date parseDate(String dateString) {
+        try {
+            return defaultDateFormat.parse(dateString);
+        } catch (Exception e) {
+            return new Date(0);
+        }
+    }
+    
+    public static String formatVersionNumber(String versionNumberFormatString,
+                                             Date projectStartDate,
+                                             VersionNumberBuildInfo info,
+                                             Map<String, String> enVars,
+                                             Calendar buildDate) {
+        String vnf = new String(versionNumberFormatString);
+        
+        int blockStart = 0;
+        do {
+            // blockStart and blockEnd define the starting and ending positions of the entire block, including
+            // the ${}
+            blockStart = vnf.indexOf("${");
+            if (blockStart >= 0) {
+                int blockEnd = vnf.indexOf("}", blockStart) + 1;
+                // if this is an unclosed block...
+                if (blockEnd <= blockStart) {
+                    // include everything up to the unclosed block, then exit
+                    vnf = vnf.substring(0, blockStart);
+                    break;
+                }
+                // command start/end include only the actual name of the variable to be replaced
+                int commandStart = blockStart + 2;
+                int commandEnd = blockEnd - 1;
+                int argumentStart = vnf.indexOf(",", blockStart);
+                int argumentEnd = 0;
+                if (argumentStart > 0 && argumentStart < blockEnd) {
+                    argumentEnd = blockEnd - 1;
+                    commandEnd = argumentStart;
+                }
+                String expressionKey = vnf.substring(commandStart, commandEnd);
+                String argumentString = argumentEnd > 0 ? vnf.substring(argumentStart + 1, argumentEnd).trim() : "";
+                String replaceValue = "";
+            
+                // we have the expression key; if it's any known key, fill in the value
+                if ("".equals(expressionKey)) {
+                    replaceValue = "";
+                } else if ("BUILD_DATE_FORMATTED".equals(expressionKey)) {
+                    DateFormat fmt = SimpleDateFormat.getInstance();
+                    if (!"".equals(argumentString)) {
+                        // this next line is a bit tricky, but basically, we're looking returning everything
+                        // inside a pair of quote marks; in other words, everything from after the first quote
+                        // to before the second
+                        String fmtString = argumentString.substring(argumentString.indexOf('"') + 1, argumentString.indexOf('"', argumentString.indexOf('"') + 1));
+                        fmt = new SimpleDateFormat(fmtString);
+                    }
+                    replaceValue = fmt.format(buildDate.getTime());
+                } else if ("BUILD_DAY".equals(expressionKey)) {
+                    replaceValue = sizeTo(Integer.toString(buildDate.get(Calendar.DAY_OF_MONTH)), argumentString.length());
+                } else if ("BUILD_WEEK".equals(expressionKey)) {
+                    replaceValue = sizeTo(Integer.toString(buildDate.get(Calendar.WEEK_OF_YEAR)), argumentString.length());
+                } else if ("BUILD_MONTH".equals(expressionKey)) {
+                    replaceValue = sizeTo(Integer.toString(buildDate.get(Calendar.MONTH) + 1), argumentString.length());
+                } else if ("BUILD_YEAR".equals(expressionKey)) {
+                    replaceValue = sizeTo(Integer.toString(buildDate.get(Calendar.YEAR)), argumentString.length());
+                } else if ("BUILDS_TODAY".equals(expressionKey)) {
+                    replaceValue = sizeTo(Integer.toString(info.getBuildsToday()), argumentString.length());
+                } else if ("BUILDS_THIS_WEEK".equals(expressionKey)) {
+                    replaceValue = sizeTo(Integer.toString(info.getBuildsThisWeek()), argumentString.length());
+                } else if ("BUILDS_THIS_MONTH".equals(expressionKey)) {
+                    replaceValue = sizeTo(Integer.toString(info.getBuildsThisMonth()), argumentString.length());
+                } else if ("BUILDS_THIS_YEAR".equals(expressionKey)) {
+                    replaceValue = sizeTo(Integer.toString(info.getBuildsThisYear()), argumentString.length());
+                } else if ("BUILDS_ALL_TIME".equals(expressionKey)) {
+                    replaceValue = sizeTo(Integer.toString(info.getBuildsAllTime()), argumentString.length());
+                } else if ("BUILDS_TODAY_Z".equals(expressionKey)) {
+                    replaceValue = sizeTo(Integer.toString(info.getBuildsToday() - 1), argumentString.length());
+                } else if ("BUILDS_THIS_MONTH_Z".equals(expressionKey)) {
+                    replaceValue = sizeTo(Integer.toString(info.getBuildsThisMonth() - 1), argumentString.length());
+                } else if ("BUILDS_THIS_YEAR_Z".equals(expressionKey)) {
+                    replaceValue = sizeTo(Integer.toString(info.getBuildsThisYear() - 1), argumentString.length());
+                } else if ("BUILDS_ALL_TIME_Z".equals(expressionKey)) {
+                    replaceValue = sizeTo(Integer.toString(info.getBuildsAllTime() - 1), argumentString.length());
+                } else if (("MONTHS_SINCE_PROJECT_START".equals(expressionKey)) && (projectStartDate != null)) {
+                    Calendar projectStartCal = Calendar.getInstance();
+                    projectStartCal.setTime(projectStartDate);
+                    int monthsSinceStart = buildDate.get(Calendar.MONTH) - projectStartCal.get(Calendar.MONTH);
+                    monthsSinceStart += (buildDate.get(Calendar.YEAR) - projectStartCal.get(Calendar.YEAR)) * 12;
+                    replaceValue = sizeTo(Integer.toString(monthsSinceStart), argumentString.length());
+                } else if (("YEARS_SINCE_PROJECT_START".equals(expressionKey)) && (projectStartDate != null)) {
+                    Calendar projectStartCal = Calendar.getInstance();
+                    projectStartCal.setTime(projectStartDate);
+                    int yearsSinceStart = buildDate.get(Calendar.YEAR) - projectStartCal.get(Calendar.YEAR);
+                    replaceValue = sizeTo(Integer.toString(yearsSinceStart), argumentString.length());
+                }
+                // if it's not one of the defined values, check the environment variables
+                else {
+                    if (enVars != null) {
+                        for (String enVarKey : enVars.keySet()) {
+                            if (enVarKey.equals(expressionKey)) {
+                                replaceValue = enVars.get(enVarKey);
+                            }
+                        }
+                    }
+                }
+                vnf = vnf.substring(0, blockStart) + replaceValue + vnf.substring(blockEnd, vnf.length());
+            }
+        } while (blockStart >= 0);
+        
+        return vnf;
+    }
+    
+    private static String sizeTo(String s, int length) {
+        while (s.length() < length) {
+            s = "0" + s;
+        }
+        return s;
+    }
+}
+

--- a/src/main/java/org/jvnet/hudson/tools/versionnumber/VersionNumberStep.java
+++ b/src/main/java/org/jvnet/hudson/tools/versionnumber/VersionNumberStep.java
@@ -52,7 +52,7 @@ import java.util.Date;
  */
 public class VersionNumberStep extends AbstractStepImpl {
  
-	private final String versionNumberString; 
+	public final String versionNumberString;
 
     @DataBoundSetter
     public boolean skipFailedBuilds = false;
@@ -75,6 +75,13 @@ public class VersionNumberStep extends AbstractStepImpl {
 		Date value = VersionNumberCommon.parseDate(this.projectStartDate);
 		if (value.compareTo(new Date(0)) != 0) {
 			return value;
+		}
+		return null;
+	}
+
+	public String getVersionPrefix() {
+		if ((this.versionPrefix != null) && (!this.versionPrefix.isEmpty())) {
+			return this.versionPrefix;
 		}
 		return null;
 	}

--- a/src/main/java/org/jvnet/hudson/tools/versionnumber/VersionNumberStep.java
+++ b/src/main/java/org/jvnet/hudson/tools/versionnumber/VersionNumberStep.java
@@ -1,0 +1,137 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2014 Jesse Glick.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.jvnet.hudson.tools.versionnumber;
+
+import com.google.inject.Inject;
+
+import org.jenkinsci.plugins.workflow.steps.AbstractStepImpl;
+import org.jenkinsci.plugins.workflow.steps.AbstractStepDescriptorImpl;
+import org.jenkinsci.plugins.workflow.steps.AbstractSynchronousStepExecution;
+import org.jenkinsci.plugins.workflow.steps.StepContextParameter;
+
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.DataBoundSetter;
+
+import hudson.Extension;
+import hudson.model.Run;
+import hudson.EnvVars;
+
+import java.util.Date;
+
+/**
+ * Returns the version number according to the
+ * specified version number string.
+ *
+ * Used like:
+ *
+ * <pre>
+ * def x = VersionNumber("${BUILDS_TODAY}")
+ * </pre>
+ */
+public class VersionNumberStep extends AbstractStepImpl {
+ 
+	private final String versionNumberString; 
+
+    @DataBoundSetter
+    public boolean skipFailedBuilds = false;
+
+    @DataBoundSetter
+    public String versionPrefix = null;
+
+    @DataBoundSetter
+    public String projectStartDate = null;
+	
+    @DataBoundConstructor
+	public VersionNumberStep(String versionNumberString) {
+		if ((versionNumberString == null) || versionNumberString.isEmpty()) {
+			throw new IllegalArgumentException("must specify a version number string.");
+		}
+		this.versionNumberString = versionNumberString;
+	}
+
+	public Date getProjectStartDate() {
+		Date value = VersionNumberCommon.parseDate(this.projectStartDate);
+		if (value.compareTo(new Date(0)) != 0) {
+			return value;
+		}
+		return null;
+	}
+
+    @Extension
+	public static final class DescriptorImpl extends AbstractStepDescriptorImpl {
+
+        public DescriptorImpl() {
+            super(Execution.class);
+        }
+
+        @Override public String getFunctionName() {
+            return "VersionNumber";
+        }
+
+        @Override public String getDisplayName() {
+            return "Determine the correct version number";
+        }
+
+    }
+
+    public static class Execution extends AbstractSynchronousStepExecution<String> {
+        
+		@StepContextParameter private transient Run run;
+		@StepContextParameter private transient EnvVars env;
+        @Inject(optional=true) private transient VersionNumberStep step;
+
+        @Override protected String run() throws Exception {
+			if (step.versionNumberString != null) {
+				try {
+					Run prevBuild = VersionNumberCommon.getPreviousBuildWithVersionNumber(run, step.versionPrefix);
+					VersionNumberBuildInfo info = VersionNumberCommon.incBuild(run, prevBuild, step.skipFailedBuilds);
+					String formattedVersionNumber = VersionNumberCommon.formatVersionNumber(step.versionNumberString,
+																step.getProjectStartDate(),
+																info,
+																env,
+																run.getTimestamp());
+					// Difference compared to freestyle jobs.
+					// If a version prefix is specified, it is forced to be prefixed.
+					// Otherwise the version prefix does not function correctly - even in freestyle jobs.
+					// In freestlye jobs it is assumed that the user reuses the version prefix
+					// within the version number string, but this assumtion is not documented.
+					// Hence, it might yield to errors, and therefore in pipeline steps, we 
+					// force the version prefix to be prefixed.
+					if (step.versionPrefix != null) {
+						formattedVersionNumber = step.versionPrefix + formattedVersionNumber;
+					}
+					run.addAction(new VersionNumberAction(info, formattedVersionNumber));
+					return formattedVersionNumber;
+				} catch (Exception e) {
+				}
+			}
+			return "";
+        }
+
+        private static final long serialVersionUID = 1L;
+
+    }
+
+}

--- a/src/main/resources/org/jvnet/hudson/tools/versionnumber/VersionNumberStep/config.jelly
+++ b/src/main/resources/org/jvnet/hudson/tools/versionnumber/VersionNumberStep/config.jelly
@@ -1,0 +1,15 @@
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define"
+	xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+	<f:entry title="${%Version Number String}" field="versionNumberString">
+		<f:textbox/>
+	</f:entry>
+	<f:entry title="${%Version Prefix}" field="versionPrefix">
+		<f:textbox/>
+	</f:entry>
+	<f:entry title="${%Project Start Date}" field="projectStartDate">
+		<f:textbox/>
+	</f:entry>
+	<f:entry title="${%Skip Failed Builds}" field="skipFailedBuilds">
+		<f:checkbox/>
+	</f:entry>
+</j:jelly>

--- a/src/main/resources/org/jvnet/hudson/tools/versionnumber/VersionNumberStep/help-projectStartDate.html
+++ b/src/main/resources/org/jvnet/hudson/tools/versionnumber/VersionNumberStep/help-projectStartDate.html
@@ -1,0 +1,6 @@
+<div>
+	<p>
+		The date the project began, in the format yyyy-MM-dd.  This is used in calculating the number of months and years
+		since the beginning of the project.
+	</p>
+</div>

--- a/src/main/resources/org/jvnet/hudson/tools/versionnumber/VersionNumberStep/help-skipFailedBuilds.html
+++ b/src/main/resources/org/jvnet/hudson/tools/versionnumber/VersionNumberStep/help-skipFailedBuilds.html
@@ -1,0 +1,8 @@
+<div>
+	<p>
+	If this box is checked, failed builds will not cause the builds today/ this month/ this year/ all time to
+	build numbers to be incremented for the next build.  Basically, this keeps failed builds from "eating" build
+	numbers.  Other rules apply; for example, if a failed build is fixed on the first build of the next day,
+	then BUILDS_TODAY will be 1 for the fixed build. 
+	</p>
+</div> 

--- a/src/main/resources/org/jvnet/hudson/tools/versionnumber/VersionNumberStep/help-versionNumberString.html
+++ b/src/main/resources/org/jvnet/hudson/tools/versionnumber/VersionNumberStep/help-versionNumberString.html
@@ -1,0 +1,123 @@
+<div>
+	<p>
+		The version number format string is used to generate the version number.  It will be passed through unaltered,
+		except that any expression of the form ${variable_name, argument} will be replaced according to the table below.
+		Arguments are option, and unless specified below, the argument is a string of length N, and the
+		number will be padded with zeros until it's length N or greater.  For example, if the build day is 5, then
+		${BUILD_DAY, XX} would return 05.
+	</p>
+	<p>
+		Any variable not recognized in the table below will be replaced by an environment variable of the same name.
+		So to use the hudson build ID, stored in the environment variable BUILD_ID, you'd just use ${BUILD_ID}.
+		If no environment variable of the appropriate name can be found, the expression will just be replaced with
+		an empty string.
+	</p>
+	<p>
+		
+		<table>
+			<tr>
+			    <td>
+			    BUILD_DATE_FORMATTED
+			    </td>
+			    <td>
+			    If the argument for this is a quotes-enclosed java date format string, then this will be replaced with
+			    the build date formatted with that string.  If there is no argument, then this will be the standard simple
+			    date format.
+			    </td>
+			</tr>
+			<tr>
+				<td>
+					BUILD_DAY
+				</td>
+				<td>
+					The day of the build.
+				</td>
+			</tr>
+			<tr>
+				<td>
+					BUILD_WEEK
+				</td>
+				<td>
+					The week of the year of the build.
+				</td>
+			</tr>
+			<tr>
+				<td>
+					BUILD_MONTH
+				</td>
+				<td>
+					The month of the build.
+				</td>
+			</tr>
+			<tr>
+				<td>
+					BUILD_YEAR
+				</td>
+				<td>
+					The year of the build.
+				</td>
+			</tr>
+			<tr>
+				<td>
+					BUILDS_TODAY
+				</td>
+				<td>
+					The number of builds done on this calendar date.
+				</td>
+			</tr>
+			<tr>
+				<td>
+					BUILDS_THIS_WEEK
+				</td>
+				<td>
+					The number of builds done in this calendar week.
+				</td>
+			</tr>
+			<tr>
+				<td>
+					BUILDS_THIS_MONTH
+				</td>
+				<td>
+					The number of builds done in this calendar month.
+				</td>
+			</tr>
+			<tr>
+				<td>
+					BUILDS_THIS_YEAR
+				</td>
+				<td>
+					The number of builds done in this calendar year.
+				</td>
+			</tr>
+			<tr>
+				<td>
+					BUILDS_ALL_TIME
+				</td>
+				<td>
+					The number of builds done since the beginning of the project.
+				</td>
+			</tr>
+			<tr>
+				<td>
+					MONTHS_SINCE_PROJECT_START
+				</td>
+				<td>
+					The number of calendar months that have elapsed since the project start date.
+				</td>
+			</tr>
+			<tr>
+				<td>
+					YEARS_SINCE_PROJECT_START
+				</td>
+				<td>
+					The number of calendar years that have elapsed since the project start date.
+				</td>
+			</tr>
+		</table>
+	</p>
+	<p>
+		Note: BUILDS_TODAY_Z, BUILDS_THIS_MONTH_Z, BUILDS_THIS_YEAR_Z and BUILDS_ALL_TIME_Z are zero-indexed
+		versions of the same variables above.  The override build numbers are NOT zero indexed, however, so if
+		you override Builds Today with 3, then BUILDS_TODAY_Z will be 2 for the next build.
+	</p>
+</div>

--- a/src/main/resources/org/jvnet/hudson/tools/versionnumber/VersionNumberStep/help-versionPrefix.html
+++ b/src/main/resources/org/jvnet/hudson/tools/versionnumber/VersionNumberStep/help-versionPrefix.html
@@ -1,0 +1,8 @@
+<div>
+	<p>
+		The prefix which is added in front of the version number to allow using the same build numbers for all the release tags.
+	</p>
+	<p>
+		Note that compared to freestyle jobs, the version prefix is always automatically added to the front of the returned version and does not have to be manually specified within the version number string above.
+	</p>
+</div> 

--- a/src/test/java/org/jvnet/hudson/tools/versionnumber/VersionNumberStepTest.java
+++ b/src/test/java/org/jvnet/hudson/tools/versionnumber/VersionNumberStepTest.java
@@ -1,0 +1,125 @@
+package org.jvnet.hudson.tools.versionnumber;
+
+import java.io.IOException;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+
+import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
+import org.jenkinsci.plugins.workflow.job.WorkflowJob;
+import org.jenkinsci.plugins.workflow.job.WorkflowRun;
+import org.jenkinsci.plugins.workflow.test.steps.SemaphoreStep;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runners.model.Statement;
+import org.jvnet.hudson.test.BuildWatcher;
+import org.jvnet.hudson.test.RestartableJenkinsRule;
+import org.jvnet.hudson.test.TestBuilder;
+
+import hudson.Launcher;
+import hudson.model.AbstractBuild;
+import hudson.model.BuildListener;
+import hudson.model.FreeStyleBuild;
+import hudson.model.FreeStyleProject;
+import hudson.model.Result;
+
+public class VersionNumberStepTest {
+
+	@Rule
+	public RestartableJenkinsRule story = new RestartableJenkinsRule();
+
+	@ClassRule
+	public static BuildWatcher buildWatcher = new BuildWatcher();
+
+	@Test
+	public void VersionNumberStep() {
+		story.addStep(new Statement() {
+			@Override
+			public void evaluate() throws Throwable {
+				String todayDate = new SimpleDateFormat("yy-MM-dd").format(new Date());
+				WorkflowJob p = story.j.jenkins.createProject(WorkflowJob.class, "p");
+				p.setDefinition(new CpsFlowDefinition(
+						"def versionNumber = VersionNumber('${BUILD_DATE_FORMATTED, \"yy-MM-dd\"}-${BUILDS_TODAY, XX}')\n" +
+						"echo \"VersionNumber: ${versionNumber}\""
+				));
+				WorkflowRun b1 = p.scheduleBuild2(0).waitForStart();
+				story.j.waitForCompletion(b1);
+				story.j.assertBuildStatus(Result.SUCCESS, b1);
+				story.j.assertLogContains("VersionNumber: " + todayDate + "-01", b1);
+				
+				WorkflowRun b2 = p.scheduleBuild2(0).waitForStart();
+				story.j.waitForCompletion(b2);
+				story.j.assertBuildStatus(Result.SUCCESS, b2);
+				story.j.assertLogContains("VersionNumber: " + todayDate + "-02", b2);
+				
+				WorkflowRun b3 = p.scheduleBuild2(0).waitForStart();
+				story.j.waitForCompletion(b3);
+				story.j.assertBuildStatus(Result.SUCCESS, b3);
+				story.j.assertLogContains("VersionNumber: " + todayDate + "-03", b3);
+			}
+		});
+	}
+	
+	@Test
+	public void VersionNumberStepPrefix() {
+		story.addStep(new Statement() {
+			@Override
+			public void evaluate() throws Throwable {
+				String todayDate = new SimpleDateFormat("yy-MM-dd").format(new Date());
+				WorkflowJob p = story.j.jenkins.createProject(WorkflowJob.class, "p");
+				p.setDefinition(new CpsFlowDefinition(
+						"def versionNumber = VersionNumber versionNumberString: '${BUILD_DATE_FORMATTED, \"yy-MM-dd\"}-${BUILDS_TODAY, XX}', versionPrefix: '1.0.'\n" +
+						"echo \"VersionNumber: ${versionNumber}\""
+				));
+				WorkflowRun b1 = p.scheduleBuild2(0).waitForStart();
+				story.j.waitForCompletion(b1);
+				story.j.assertBuildStatus(Result.SUCCESS, b1);
+				story.j.assertLogContains("VersionNumber: 1.0." + todayDate + "-01", b1);
+				
+				WorkflowRun b2 = p.scheduleBuild2(0).waitForStart();
+				story.j.waitForCompletion(b2);
+				story.j.assertBuildStatus(Result.SUCCESS, b2);
+				story.j.assertLogContains("VersionNumber: 1.0." + todayDate + "-02", b2);
+				
+				p.setDefinition(new CpsFlowDefinition(
+						"def versionNumber = VersionNumber versionNumberString: '${BUILD_DATE_FORMATTED, \"yy-MM-dd\"}-${BUILDS_TODAY, XX}', versionPrefix: '1.5.'\n" +
+						"echo \"VersionNumber: ${versionNumber}\""
+				));
+				WorkflowRun b3 = p.scheduleBuild2(0).waitForStart();
+				story.j.waitForCompletion(b3);
+				story.j.assertBuildStatus(Result.SUCCESS, b3);
+				story.j.assertLogContains("VersionNumber: 1.5." + todayDate + "-01", b3);
+				
+				p.setDefinition(new CpsFlowDefinition(
+						"def versionNumber = VersionNumber versionNumberString: '${BUILD_DATE_FORMATTED, \"yy-MM-dd\"}-${BUILDS_TODAY, XX}', versionPrefix: '1.0.'\n" +
+						"echo \"VersionNumber: ${versionNumber}\""
+				));
+				WorkflowRun b4 = p.scheduleBuild2(0).waitForStart();
+				story.j.waitForCompletion(b4);
+				story.j.assertBuildStatus(Result.SUCCESS, b4);
+				story.j.assertLogContains("VersionNumber: 1.0." + todayDate + "-03", b4);
+			}
+		});
+	}
+	
+	@Test
+	public void VersionNumberStepEnvironment() {
+		story.addStep(new Statement() {
+			@Override
+			public void evaluate() throws Throwable {
+				String todayDate = new SimpleDateFormat("yy-MM-dd").format(new Date());
+				WorkflowJob p = story.j.jenkins.createProject(WorkflowJob.class, "p");
+				p.setDefinition(new CpsFlowDefinition(
+				        "withEnv(['envVar=Hello']) {\n" +
+						"   def versionNumber = VersionNumber('${envVar}-${BUILD_DATE_FORMATTED, \"yy-MM-dd\"}-${BUILDS_TODAY, XX}')\n" +
+						"   echo \"VersionNumber: ${versionNumber}\"\n" +
+                        "}"
+				));
+				WorkflowRun b1 = p.scheduleBuild2(0).waitForStart();
+				story.j.waitForCompletion(b1);
+				story.j.assertBuildStatus(Result.SUCCESS, b1);
+				story.j.assertLogContains("VersionNumber: Hello-" + todayDate + "-01", b1);
+			}
+		});
+	}
+}


### PR DESCRIPTION
This pull-request shall add basic pipeline support for Jenkins "Pipeline-as-Code".
Basically this pull-request can be divided in three parts:
- Refactoring the main methods from `VersionNumberBuilder.java` to static methods which are moved to `VersionNumberCommon.java`
- Added Pipeline support by updating `pom.xml` and introducing a `VersionNumberStep.java`.
- Adding necessary help files for the Pipeline Snippet Generator.

Note that there is a different **usage pattern** when dealing with the `versionPrefix`. To set environment variables within a pipeline it is needed to use the `withEnv` step (in order to work correctly for the current thread, which might be on a node). Hence, when handling the version prefix as before, it would be necessary to combine it always with an `withEnv` step. To avoid this coupling, the specified `versionPrefix` is now **always added* at the front of the returned version string, even if it is not specified within the `versionNumberString`.

Basic usage examples are e.g.
```java
def version = VersionNumber('${BUILD_DATE_FORMATTED, \"yy-MM-dd\"}-${BUILDS_TODAY, XX}')
// returns e.g. 16-04-17-01
```

or using the optional arguments, e.g.
```java
def version = VersionNumber(versionNumberString: '${BUILD_DATE_FORMATTED, \"yy.MM.dd\"}.${BUILDS_TODAY, XX}', versionPrefix: '1.0.')
// return e.g. 1.0.16.04.16.01
// Note that the versionPrefix is automatically added to the front,
// even though it is not specified within the versionNumberString.
```

Corresponding Unittests are attached as well.
Would we great if we could get this merged into the master.

PS: Since this is only my second contribution to jenkins plugins, I'm very open for any kind of comments, feedback or adjustments. Please let me know if there's anything to improve.

cc @Bagira80 