### PR TITLE
Added supported to override BUILDS_ALL_TIME via pipeline in the same …

### DIFF
--- a/src/main/java/org/jvnet/hudson/tools/versionnumber/AbstractBuildNumberGenerator.java
+++ b/src/main/java/org/jvnet/hudson/tools/versionnumber/AbstractBuildNumberGenerator.java
@@ -1,0 +1,94 @@
+package org.jvnet.hudson.tools.versionnumber;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import hudson.EnvVars;
+import hudson.model.Result;
+import hudson.model.Run;
+
+public abstract class AbstractBuildNumberGenerator implements BuildNumberGenerator {
+		
+	@Override
+	public int getNextNumber(Run build, EnvVars vars, Run prevBuild, boolean skipFailedBuilds, String override) {
+    	int nextNumber = 1;
+    	
+    	// Attempt an override
+    	if (override != null && isValidOverride(vars, override)) {
+    		nextNumber = resolveOverride(vars, override);
+    	// If no override, start from the previous build
+    	} else if (prevBuild != null) {
+    		int increment = 1;
+            // if we're skipping version numbers on failed builds and the last build failed...
+            if (skipFailedBuilds) {
+                Result result = prevBuild.getResult();
+                if (result != null && ! result.equals(Result.SUCCESS)) {
+                    // don't increment
+                    increment = 0;
+                }
+            }
+            
+            nextNumber = resolveValue(build, prevBuild, increment);
+    	}
+    	
+    	return nextNumber;
+	}
+	
+    protected VersionNumberBuildInfo getPreviousBuildInfo(Run prevBuild) {
+		VersionNumberAction prevAction = (VersionNumberAction)prevBuild.getAction(VersionNumberAction.class);
+		VersionNumberBuildInfo info = prevAction.getInfo();
+		return info;
+	}
+	        
+    /**
+     * Returns true if the passed override results to a valid value greater than
+     * or equal to 0, false otherwise.
+     * 
+     * @param envVars The environment variables.
+     * @param override The override string, such as buildsAllTime
+     * @return True if the override results in a valid value.
+     */
+    public static boolean isValidOverride(EnvVars envVars, String override) {
+    	return resolveOverride(envVars, override) != null;
+    }
+    
+    /**
+     * Given an override, see if it resolves to a valid integer greater than
+     * or equal to zero from either an environment variable or a direct
+     * conversion.
+     * 
+     * @param envVars The environment variables.
+     * @param override The override string, such as buildsAllTime
+     * @return The integer value of the override or null if conversion
+     * does not result in a valid value.
+     */
+    public static Integer resolveOverride(EnvVars envVars, String override) {
+    	Integer result = null;
+        Pattern pattern = Pattern.compile(VersionNumberCommon.ENV_VAR_PATTERN);
+
+		// Just in case someone directly edited the config-file with invalid values.
+        override = VersionNumberCommon.makeValid(override);
+
+		try {
+		    if (!override.matches(VersionNumberCommon.ENV_VAR_PATTERN)) {
+		        result = Integer.parseInt(override);
+		        override = "";  // Reset!
+		    } else {
+		        Matcher m = pattern.matcher(override);
+		        if (m.matches()) {
+		          String varName = (m.group(1) != null) ? m.group(1) : m.group(2);
+		          result = Integer.parseInt(envVars.get(varName));
+		        }
+		    }
+		} catch (Exception e) {
+		    // Invalid value, so do not override!
+		}
+		
+		if (result == null || result < 0) {
+			result = null;
+		}
+
+		return result;
+    }
+    
+}

--- a/src/main/java/org/jvnet/hudson/tools/versionnumber/BuildNumberGenerator.java
+++ b/src/main/java/org/jvnet/hudson/tools/versionnumber/BuildNumberGenerator.java
@@ -1,0 +1,12 @@
+package org.jvnet.hudson.tools.versionnumber;
+
+import hudson.EnvVars;
+import hudson.model.Run;
+
+public interface BuildNumberGenerator {
+
+	int getNextNumber(Run build, EnvVars vars, Run prevBuild, boolean skipFailedBuilds, String override);
+	
+	int resolveValue(Run build, Run previousBuild, int increment);
+	
+}

--- a/src/main/java/org/jvnet/hudson/tools/versionnumber/BuildsAllTimeGenerator.java
+++ b/src/main/java/org/jvnet/hudson/tools/versionnumber/BuildsAllTimeGenerator.java
@@ -1,0 +1,20 @@
+package org.jvnet.hudson.tools.versionnumber;
+
+import hudson.model.Run;
+
+public class BuildsAllTimeGenerator extends AbstractBuildNumberGenerator {
+
+	@Override
+	public int resolveValue(Run build, Run prevBuild, int increment) {
+		int nextNumber;
+		
+        // get the previous build version number information
+        VersionNumberBuildInfo info = getPreviousBuildInfo(prevBuild);
+
+        nextNumber = info.getBuildsAllTime() + increment;
+        
+        return nextNumber;
+		
+	}
+
+}

--- a/src/main/java/org/jvnet/hudson/tools/versionnumber/BuildsThisMonthGenerator.java
+++ b/src/main/java/org/jvnet/hudson/tools/versionnumber/BuildsThisMonthGenerator.java
@@ -1,0 +1,33 @@
+package org.jvnet.hudson.tools.versionnumber;
+
+import java.util.Calendar;
+
+import hudson.model.Run;
+
+public class BuildsThisMonthGenerator extends AbstractBuildNumberGenerator {
+
+	@Override
+	public int resolveValue(Run build, Run prevBuild, int increment) {
+		int nextNumber;
+		
+        // get the current build date and the previous build date
+        Calendar curCal = build.getTimestamp();
+        Calendar todayCal = prevBuild.getTimestamp();
+        
+        // get the previous build version number information
+        VersionNumberBuildInfo info = getPreviousBuildInfo(prevBuild);
+
+        // increment builds per day
+        // increment builds per month
+        if (curCal.get(Calendar.MONTH) == todayCal.get(Calendar.MONTH)
+                && curCal.get(Calendar.YEAR) == todayCal.get(Calendar.YEAR)) {
+        	nextNumber = info.getBuildsThisMonth() + increment;
+        } else {
+        	nextNumber = 1;
+        }
+        
+        return nextNumber;
+		
+	}
+
+}

--- a/src/main/java/org/jvnet/hudson/tools/versionnumber/BuildsThisWeekGenerator.java
+++ b/src/main/java/org/jvnet/hudson/tools/versionnumber/BuildsThisWeekGenerator.java
@@ -1,0 +1,32 @@
+package org.jvnet.hudson.tools.versionnumber;
+
+import java.util.Calendar;
+
+import hudson.model.Run;
+
+public class BuildsThisWeekGenerator extends AbstractBuildNumberGenerator {
+
+	@Override
+	public int resolveValue(Run build, Run prevBuild, int increment) {
+		int nextNumber;
+		
+        // get the current build date and the previous build date
+        Calendar curCal = build.getTimestamp();
+        Calendar todayCal = prevBuild.getTimestamp();
+        
+        // get the previous build version number information
+        VersionNumberBuildInfo info = getPreviousBuildInfo(prevBuild);
+
+        // increment builds per week
+        if (curCal.get(Calendar.WEEK_OF_YEAR) == todayCal.get(Calendar.WEEK_OF_YEAR)
+                && curCal.get(Calendar.YEAR) == todayCal.get(Calendar.YEAR)) {
+        	nextNumber = info.getBuildsThisWeek() + increment;
+        } else {
+        	nextNumber = 1;
+        }
+        
+        return nextNumber;
+		
+	}
+
+}

--- a/src/main/java/org/jvnet/hudson/tools/versionnumber/BuildsThisYearGenerator.java
+++ b/src/main/java/org/jvnet/hudson/tools/versionnumber/BuildsThisYearGenerator.java
@@ -1,0 +1,30 @@
+package org.jvnet.hudson.tools.versionnumber;
+
+import java.util.Calendar;
+
+import hudson.model.Run;
+
+public class BuildsThisYearGenerator extends AbstractBuildNumberGenerator {
+
+	@Override
+	public int resolveValue(Run build, Run prevBuild, int increment) {
+		int nextNumber;
+		
+        // get the current build date and the previous build date
+        Calendar curCal = build.getTimestamp();
+        Calendar todayCal = prevBuild.getTimestamp();
+        
+        // get the previous build version number information
+        VersionNumberBuildInfo info = getPreviousBuildInfo(prevBuild);
+
+        if (curCal.get(Calendar.YEAR) == todayCal.get(Calendar.YEAR)) {
+        	nextNumber = info.getBuildsThisYear() + increment;
+        } else {
+        	nextNumber = 1;
+        }
+        
+        return nextNumber;
+		
+	}
+
+}

--- a/src/main/java/org/jvnet/hudson/tools/versionnumber/BuildsTodayGenerator.java
+++ b/src/main/java/org/jvnet/hudson/tools/versionnumber/BuildsTodayGenerator.java
@@ -1,0 +1,33 @@
+package org.jvnet.hudson.tools.versionnumber;
+
+import java.util.Calendar;
+
+import hudson.model.Run;
+
+public class BuildsTodayGenerator extends AbstractBuildNumberGenerator {
+
+	@Override
+	public int resolveValue(Run build, Run prevBuild, int increment) {
+		int nextNumber;
+		
+        // get the current build date and the previous build date
+        Calendar curCal = build.getTimestamp();
+        Calendar todayCal = prevBuild.getTimestamp();
+        
+        // get the previous build version number information
+        VersionNumberBuildInfo info = getPreviousBuildInfo(prevBuild);
+
+        // increment builds per day
+        if (curCal.get(Calendar.DAY_OF_MONTH) == todayCal.get(Calendar.DAY_OF_MONTH)
+                && curCal.get(Calendar.MONTH) == todayCal.get(Calendar.MONTH)
+                && curCal.get(Calendar.YEAR) == todayCal.get(Calendar.YEAR)) {
+            nextNumber = info.getBuildsToday() + increment;
+        } else {
+            nextNumber = 1;
+        }
+        
+        return nextNumber;
+		
+	}
+
+}

--- a/src/main/java/org/jvnet/hudson/tools/versionnumber/VersionNumberBuilder.java
+++ b/src/main/java/org/jvnet/hudson/tools/versionnumber/VersionNumberBuilder.java
@@ -1,34 +1,30 @@
 package org.jvnet.hudson.tools.versionnumber;
 
-import hudson.Extension;
+import java.io.IOException;
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.QueryParameter;
+import org.kohsuke.stapler.StaplerRequest;
+
 import hudson.EnvVars;
+import hudson.Extension;
 import hudson.Launcher;
-import hudson.model.BuildListener;
-import hudson.model.Result;
 import hudson.model.AbstractBuild;
 import hudson.model.AbstractProject;
+import hudson.model.BuildListener;
+import hudson.model.Result;
 import hudson.model.Run;
 import hudson.tasks.BuildWrapper;
 import hudson.tasks.BuildWrapperDescriptor;
 import hudson.tasks.Builder;
 import hudson.util.FormValidation;
-
-import java.io.IOException;
-import java.io.PrintStream;
-import java.text.DateFormat;
-import java.text.SimpleDateFormat;
-import java.util.Calendar;
-import java.util.Date;
-import java.util.Map;
-import java.util.logging.Logger;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-
 import net.sf.json.JSONObject;
-
-import org.kohsuke.stapler.DataBoundConstructor;
-import org.kohsuke.stapler.QueryParameter;
-import org.kohsuke.stapler.StaplerRequest;
 
 /**
  * Sample {@link Builder}.
@@ -179,115 +175,97 @@ public class VersionNumberBuilder extends BuildWrapper {
         return VersionNumberCommon.getPreviousBuildWithVersionNumber(build, envPrefix);
     }
     
+    private boolean isOverrideString(String override) {
+    	boolean result = false;
+    	
+    	if (override != null && !override.equals("")) {
+    		result = true;
+    	}
+    	return result;
+    }
+    
     @SuppressWarnings("unchecked")
     private VersionNumberBuildInfo incBuild(Run build, BuildListener listener) throws IOException, InterruptedException {
         EnvVars enVars = build.getEnvironment(listener);
         Run prevBuild = getPreviousBuildWithVersionNumber(build, listener);
-        VersionNumberBuildInfo incBuildInfo = VersionNumberCommon.incBuild(build, enVars, prevBuild, this.skipFailedBuilds, this.oBuildsAllTime);
+        VersionNumberBuildInfo incBuildInfo = VersionNumberCommon.incBuild(build, enVars, prevBuild,
+        		this.skipFailedBuilds,
+        		this.oBuildsToday,
+        		this.oBuildsThisWeek,
+        		this.oBuildsThisMonth,
+        		this.oBuildsThisYear,
+        		this.oBuildsAllTime);
         
         // have we overridden any of the version number info?  If so, set it up here
         boolean saveOverrides = false;
-        Pattern pattern = Pattern.compile(VersionNumberCommon.ENV_VAR_PATTERN);
-
-        int buildsToday = incBuildInfo.getBuildsToday();
-        int buildsThisWeek = incBuildInfo.getBuildsThisWeek();
-        int buildsThisMonth = incBuildInfo.getBuildsThisMonth();
-        int buildsThisYear = incBuildInfo.getBuildsThisYear();
-        int buildsAllTime = incBuildInfo.getBuildsAllTime();
+        
         if (this.oBuildsToday == null || !this.oBuildsToday.equals("")) {
             saveOverrides = true;  // Always need to save if not empty!
             // Just in case someone directly edited the config-file with invalid values.
             oBuildsToday = VersionNumberCommon.makeValid(oBuildsToday);
-            int newVal = buildsToday;
             try {
                 if (!oBuildsToday.matches(VersionNumberCommon.ENV_VAR_PATTERN)) {
-                    newVal = Integer.parseInt(oBuildsToday);
                     oBuildsToday = "";  // Reset!
-                } else {
-                    Matcher m = pattern.matcher(oBuildsToday);
-                    if (m.matches()) {
-                      String varName = (m.group(1) != null) ? m.group(1) : m.group(2);
-                      newVal = Integer.parseInt(enVars.get(varName));
-                    }
                 }
             } catch (Exception e) {
                 // Invalid value, so do not override!
             }
-            buildsToday = ((newVal >= 0) ? newVal : buildsToday);
         }
+        
         if (this.oBuildsThisWeek == null || !this.oBuildsThisWeek.equals("")) {
             saveOverrides = true;  // Always need to save if not empty!
             // Just in case someone directly edited the config-file with invalid values.
             oBuildsThisWeek = VersionNumberCommon.makeValid(oBuildsThisWeek);
-            int newVal = buildsThisWeek;
             try {
                 if (!oBuildsThisWeek.matches(VersionNumberCommon.ENV_VAR_PATTERN)) {
-                    newVal = Integer.parseInt(oBuildsThisWeek);
                     oBuildsThisWeek = "";  // Reset!
-                } else {
-                    Matcher m = pattern.matcher(oBuildsThisWeek);
-                    if (m.matches()) {
-                        String varName = (m.group(1) != null) ? m.group(1) : m.group(2);
-                        newVal = Integer.parseInt(enVars.get(varName));
-                    }
                 }
             } catch (Exception e) {
                 // Invalid value, so do not override!
             }
-            buildsThisWeek = ((newVal >= 0) ? newVal : buildsThisWeek);
         }
         if (this.oBuildsThisMonth == null || !this.oBuildsThisMonth.equals("")) {
             saveOverrides = true;  // Always need to save if not empty!
             // Just in case someone directly edited the config-file with invalid values.
             oBuildsThisMonth = VersionNumberCommon.makeValid(oBuildsThisMonth);
-            int newVal = buildsThisMonth;
             try {
                 if (!oBuildsThisMonth.matches(VersionNumberCommon.ENV_VAR_PATTERN)) {
-                    newVal = Integer.parseInt(oBuildsThisMonth);
                     oBuildsThisMonth = "";  // Reset!
-                } else {
-                    Matcher m = pattern.matcher(oBuildsThisMonth);
-                    if (m.matches()) {
-                      String varName = (m.group(1) != null) ? m.group(1) : m.group(2);
-                      newVal = Integer.parseInt(enVars.get(varName));
-                    }
                 }
             } catch (Exception e) {
                 // Invalid value, so do not override!
             }
-            buildsThisMonth = ((newVal >= 0) ? newVal : buildsThisMonth);
         }
         if (this.oBuildsThisYear == null || !this.oBuildsThisYear.equals("")) {
             saveOverrides = true;  // Always need to save if not empty!
             // Just in case someone directly edited the config-file with invalid values.
             oBuildsThisYear = VersionNumberCommon.makeValid(oBuildsThisYear);
-            int newVal = buildsThisYear;
             try {
                 if (!oBuildsThisYear.matches(VersionNumberCommon.ENV_VAR_PATTERN)) {
-                    newVal = Integer.parseInt(oBuildsThisYear);
                     oBuildsThisYear = "";  // Reset!
-                } else {
-                    Matcher m = pattern.matcher(oBuildsThisYear);
-                    if (m.matches()) {
-                      String varName = (m.group(1) != null) ? m.group(1) : m.group(2);
-                      newVal = Integer.parseInt(enVars.get(varName));
-                    }
                 }
             } catch (Exception e) {
                 // Invalid value, so do not override!
             }
-            buildsThisYear = ((newVal >= 0) ? newVal : buildsThisYear);
         }
         
         if (this.oBuildsAllTime == null || !this.oBuildsAllTime.equals("")) {
             saveOverrides = true;  // Always need to save if not empty!
+            oBuildsAllTime = VersionNumberCommon.makeValid(oBuildsAllTime);
+            try {
+                if (!oBuildsAllTime.matches(VersionNumberCommon.ENV_VAR_PATTERN)) {
+                	oBuildsAllTime = "";  // Reset!
+                }
+            } catch (Exception e) {
+                // Invalid value, so do not override!
+            }
         }
         
         // if we've used any of the overrides, reset them in the project
         if (saveOverrides) {
             build.getParent().save();
         }
-        return new VersionNumberBuildInfo(buildsToday, buildsThisWeek, buildsThisMonth, buildsThisYear, buildsAllTime);
+        return incBuildInfo;
     }
     
     @SuppressWarnings("unchecked") @Override

--- a/src/main/java/org/jvnet/hudson/tools/versionnumber/VersionNumberCommon.java
+++ b/src/main/java/org/jvnet/hudson/tools/versionnumber/VersionNumberCommon.java
@@ -1,34 +1,13 @@
 package org.jvnet.hudson.tools.versionnumber;
 
-import hudson.Extension;
-import hudson.EnvVars;
-import hudson.Launcher;
-import hudson.model.BuildListener;
-import hudson.model.Result;
-import hudson.model.AbstractBuild;
-import hudson.model.AbstractProject;
-import hudson.model.Run;
-import hudson.tasks.BuildWrapper;
-import hudson.tasks.BuildWrapperDescriptor;
-import hudson.tasks.Builder;
-import hudson.util.FormValidation;
-
-import java.io.IOException;
-import java.io.PrintStream;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.Map;
-import java.util.logging.Logger;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
-import net.sf.json.JSONObject;
-
-import org.kohsuke.stapler.DataBoundConstructor;
-import org.kohsuke.stapler.QueryParameter;
-import org.kohsuke.stapler.StaplerRequest;
+import hudson.EnvVars;
+import hudson.model.Run;
 
 /**
  * Common methods used by freestyle and pipeline jobs.
@@ -36,94 +15,20 @@ import org.kohsuke.stapler.StaplerRequest;
 public class VersionNumberCommon {
     
     private static final String DEFAULT_DATE_FORMAT_PATTERN = "yyyy-MM-dd";
-    
+
     // Pattern:   ${VAR_NAME} or $VAR_NAME
     public static final String ENV_VAR_PATTERN = "^(?:\\$\\{(\\w+)\\})|(?:\\$(\\w+))$";
     
-    public static VersionNumberBuildInfo incBuild(Run build, EnvVars environmentVariables,
-    		Run prevBuild, boolean skipFailedBuilds, String overrideBuildsAllTime) {
-        int buildsToday = 1;
-        int buildsThisWeek = 1;
-        int buildsThisMonth = 1;
-        int buildsThisYear = 1;
-        int buildsAllTime = 1;
-        // this is what we add to the previous version number to get builds today / this week / this month / this year / all time
-        int buildInc = 1;
-
-        /*
-         * If we're overriding builds all time, figure it out here.  If we don't
-         * it will be business as usual and we'll increment as needed.
-         * 
-         * It's necessary to do this here in case you want to override the build
-         * number on the very first build.
-         */
-        if (isValidOverrideBuildsAllTime(environmentVariables, overrideBuildsAllTime)) {
-        	buildsAllTime = getOverrideBuildsAllTime(environmentVariables, overrideBuildsAllTime);
-        }
-        
-        if (prevBuild != null) {
-            // if we're skipping version numbers on failed builds and the last build failed...
-            if (skipFailedBuilds) {
-                Result result = prevBuild.getResult();
-                if (result != null && ! result.equals(Result.SUCCESS)) {
-                    // don't increment
-                    buildInc = 0;
-                }
-            }
-            // get the current build date and the previous build date
-            Calendar curCal = build.getTimestamp();
-            Calendar todayCal = prevBuild.getTimestamp();
-            
-            // get the previous build version number information
-            VersionNumberAction prevAction = (VersionNumberAction)prevBuild.getAction(VersionNumberAction.class);
-            VersionNumberBuildInfo info = prevAction.getInfo();
-
-            // increment builds per day
-            if (curCal.get(Calendar.DAY_OF_MONTH) == todayCal.get(Calendar.DAY_OF_MONTH)
-                    && curCal.get(Calendar.MONTH) == todayCal.get(Calendar.MONTH)
-                    && curCal.get(Calendar.YEAR) == todayCal.get(Calendar.YEAR)) {
-                buildsToday = info.getBuildsToday() + buildInc;
-            } else {
-                buildsToday = 1;
-            }
-
-            // increment builds per week
-            if (curCal.get(Calendar.WEEK_OF_YEAR) == todayCal.get(Calendar.WEEK_OF_YEAR)
-                    && curCal.get(Calendar.YEAR) == todayCal.get(Calendar.YEAR)) {
-                buildsThisWeek = info.getBuildsThisWeek() + buildInc;
-            } else {
-                buildsThisWeek = 1;
-            }
-
-            // increment builds per month
-            if (curCal.get(Calendar.MONTH) == todayCal.get(Calendar.MONTH)
-                    && curCal.get(Calendar.YEAR) == todayCal.get(Calendar.YEAR)) {
-                buildsThisMonth = info.getBuildsThisMonth() + buildInc;
-            } else {
-                buildsThisMonth = 1;
-            }
-
-            // increment builds per year
-            if (curCal.get(Calendar.YEAR) == todayCal.get(Calendar.YEAR)) {
-                buildsThisYear = info.getBuildsThisYear() + buildInc;
-            } else {
-                buildsThisYear = 1;
-            }
-
-            /*
-			 * If there's a valid override, we'll keep it, otherwise increment as normal.
-			 * 
-			 * TODO:  Not totally thrilled with this solution, but....
-			 * 
-			 * It's necessary to test this again here since we don't want to increment
-			 * the number if we've already resolved this from the beginning of the method.
-             */
-            if (!isValidOverrideBuildsAllTime(environmentVariables, overrideBuildsAllTime)) {
-	            // increment total builds
-	            buildsAllTime = info.getBuildsAllTime() + buildInc;
-            }
-        }
-        
+    public static VersionNumberBuildInfo incBuild(Run build, EnvVars vars,
+    		Run prevBuild, boolean skipFailedBuilds, String overrideBuildsToday, String overrideBuildsThisWeek,
+    		String overrideBuildsThisMonth, String overrideBuildsThisYear, String overrideBuildsAllTime) {
+    	
+    	int buildsToday = new BuildsTodayGenerator().getNextNumber(build, vars, prevBuild, skipFailedBuilds, overrideBuildsToday);
+    	int buildsThisWeek = new BuildsThisWeekGenerator().getNextNumber(build, vars, prevBuild, skipFailedBuilds, overrideBuildsThisWeek);
+    	int buildsThisMonth = new BuildsThisMonthGenerator().getNextNumber(build, vars, prevBuild, skipFailedBuilds, overrideBuildsThisMonth);
+    	int buildsThisYear = new BuildsThisYearGenerator().getNextNumber(build, vars, prevBuild, skipFailedBuilds, overrideBuildsThisYear);
+    	int buildsAllTime = new BuildsAllTimeGenerator().getNextNumber(build, vars, prevBuild, skipFailedBuilds, overrideBuildsAllTime);
+                
         return new VersionNumberBuildInfo(buildsToday, buildsThisWeek, buildsThisMonth, buildsThisYear, buildsAllTime);
     }
     
@@ -160,63 +65,7 @@ public class VersionNumberCommon {
             return new Date(0);
         }
     }
-    
-    /**
-     * Returns true if the passed builds all time value resolves to a value greater
-     * than or equal to 0 based on either an environment variable or direct integer
-     * parsing.
-     * 
-     * @param envVars
-     * @param buildsAllTime
-     * @return
-     */
-    private static boolean isValidOverrideBuildsAllTime(EnvVars envVars, String buildsAllTime) {
-    	boolean result = false;
-    	
-    	if (buildsAllTime != null && !buildsAllTime.equals("")) {
-    		result = getOverrideBuildsAllTime(envVars, buildsAllTime) != null;
-    	}
-    	
-    	return result;
-    }
-    
-    /**
-     * Given an override builds all time, first check if it is an environment variable that
-     * resolves, otherwise try converting directly to an int.
-     * 
-     * @param envVars The environment variables to the build.
-     * @param buildsAllTime A string either resolving to an int or an environment variable that can provide the next value.
-     * @return The new build number or null if we can't resolve as a number greater than or equal to 0
-     */
-    private static Integer getOverrideBuildsAllTime(EnvVars envVars, String buildsAllTime) {
-    	Integer result = null;
-        Pattern pattern = Pattern.compile(VersionNumberCommon.ENV_VAR_PATTERN);
-
-		// Just in case someone directly edited the config-file with invalid values.
-		buildsAllTime = makeValid(buildsAllTime);
-
-		try {
-		    if (!buildsAllTime.matches(VersionNumberCommon.ENV_VAR_PATTERN)) {
-		        result = Integer.parseInt(buildsAllTime);
-		        buildsAllTime = "";  // Reset!
-		    } else {
-		        Matcher m = pattern.matcher(buildsAllTime);
-		        if (m.matches()) {
-		          String varName = (m.group(1) != null) ? m.group(1) : m.group(2);
-		          result = Integer.parseInt(envVars.get(varName));
-		        }
-		    }
-		} catch (Exception e) {
-		    // Invalid value, so do not override!
-		}
-		
-		if (result == null || result < 0) {
-			result = null;
-		}
-
-		return result;
-    }
-    
+        
 	public static String formatVersionNumber(String versionNumberFormatString,
                                              Date projectStartDate,
                                              VersionNumberBuildInfo info,
@@ -326,17 +175,17 @@ public class VersionNumberCommon {
      * valid value encoded in the string must either be a (positive) number,
      * convertible to an integer or a reference to an environment-variable in
      * the form <code>${VARIABLE_NAME}</code> or <code>$VARIABLE_NAME</code>.
-     * @param buildNum The (user-provided) string which should either contain
+     * @param value The (user-provided) string which should either contain
      *                 a number or a reference to an environment-variable.
      * @return The given <a>buildNum</a> if valid or an empty string.
      */
-    public static String makeValid(String buildNum) {
-        if (buildNum == null) return "";  // Return the default-value.
+    public static String makeValid(String value) {
+        if (value == null) return "";  // Return the default-value.
         try {
-            buildNum = buildNum.trim();
+            value = value.trim();
             // If we got a valid integer the following conversion will
             // succeed without an exception.
-            Integer intVal = Integer.valueOf(buildNum);
+            Integer intVal = Integer.valueOf(value);
             if (intVal < 0)
                 return "";  // Negative numbers are not allowed.
             else
@@ -344,11 +193,11 @@ public class VersionNumberCommon {
         } catch (Exception e) {
             // Obviously, we did not receive a valid integer as override.
             // Is it a reference to an environment-variable?
-            if (buildNum.matches(VersionNumberCommon.ENV_VAR_PATTERN)) {
+            if (value.matches(VersionNumberCommon.ENV_VAR_PATTERN)) {
                 // Yes, so return it as-is and only retrieve its value when
                 // the value must be accessed (to always get the most
                 // up-to-date value).
-                return buildNum;
+                return value;
             } else {
                 // No, so it seems to be junk. Just return the default-value.
                 return "";

--- a/src/main/java/org/jvnet/hudson/tools/versionnumber/VersionNumberStep.java
+++ b/src/main/java/org/jvnet/hudson/tools/versionnumber/VersionNumberStep.java
@@ -63,6 +63,9 @@ public class VersionNumberStep extends AbstractStepImpl {
     @DataBoundSetter
     public String projectStartDate = null;
 	
+    @DataBoundSetter
+    public String buildsAllTime = null;
+    
     @DataBoundConstructor
 	public VersionNumberStep(String versionNumberString) {
 		if ((versionNumberString == null) || versionNumberString.isEmpty()) {
@@ -113,7 +116,8 @@ public class VersionNumberStep extends AbstractStepImpl {
 			if (step.versionNumberString != null) {
 				try {
 					Run prevBuild = VersionNumberCommon.getPreviousBuildWithVersionNumber(run, step.versionPrefix);
-					VersionNumberBuildInfo info = VersionNumberCommon.incBuild(run, prevBuild, step.skipFailedBuilds);
+					VersionNumberBuildInfo info = VersionNumberCommon.incBuild(run, env, prevBuild, step.skipFailedBuilds, step.buildsAllTime);
+					
 					String formattedVersionNumber = VersionNumberCommon.formatVersionNumber(step.versionNumberString,
 																step.getProjectStartDate(),
 																info,

--- a/src/main/java/org/jvnet/hudson/tools/versionnumber/VersionNumberStep.java
+++ b/src/main/java/org/jvnet/hudson/tools/versionnumber/VersionNumberStep.java
@@ -64,7 +64,19 @@ public class VersionNumberStep extends AbstractStepImpl {
     public String projectStartDate = null;
 	
     @DataBoundSetter
-    public String buildsAllTime = null;
+    public String overrideBuildsAllTime = null;
+    
+    @DataBoundSetter
+    public String overrideBuildsToday = null;
+    
+    @DataBoundSetter
+    public String overrideBuildsThisWeek = null;
+    
+    @DataBoundSetter
+    public String overrideBuildsThisMonth = null;
+    
+    @DataBoundSetter
+    public String overrideBuildsThisYear = null;
     
     @DataBoundConstructor
 	public VersionNumberStep(String versionNumberString) {
@@ -116,7 +128,12 @@ public class VersionNumberStep extends AbstractStepImpl {
 			if (step.versionNumberString != null) {
 				try {
 					Run prevBuild = VersionNumberCommon.getPreviousBuildWithVersionNumber(run, step.versionPrefix);
-					VersionNumberBuildInfo info = VersionNumberCommon.incBuild(run, env, prevBuild, step.skipFailedBuilds, step.buildsAllTime);
+					VersionNumberBuildInfo info = VersionNumberCommon.incBuild(run, env, prevBuild, step.skipFailedBuilds,
+							step.overrideBuildsToday,
+							step.overrideBuildsThisWeek,
+							step.overrideBuildsThisMonth,
+							step.overrideBuildsThisYear,
+							step.overrideBuildsAllTime);
 					
 					String formattedVersionNumber = VersionNumberCommon.formatVersionNumber(step.versionNumberString,
 																step.getProjectStartDate(),

--- a/src/test/java/org/jvnet/hudson/tools/versionnumber/VersionNumberBuilderTest.java
+++ b/src/test/java/org/jvnet/hudson/tools/versionnumber/VersionNumberBuilderTest.java
@@ -129,6 +129,36 @@ public class VersionNumberBuilderTest extends HudsonTestCase {
         job.getBuildWrappersList().add(versionNumberBuilder);
         FreeStyleBuild build = buildAndAssertSuccess(job);
         assertEquals("1.1.1.1.20", build.getDisplayName());
+        
+        // make sure that the overrides via environment variables remain
+        assertEquals("${ENVVAL_OF_ALL_TIME}", versionNumberBuilder.getBuildsAllTime());
+        assertEquals("${ENVVAL_OF_TODAY}", versionNumberBuilder.getBuildsToday());
+        assertEquals("${ENVVAL_OF_THIS_WEEK}", versionNumberBuilder.getBuildsThisWeek());
+        assertEquals("${ENVVAL_OF_THIS_MONTH}", versionNumberBuilder.getBuildsThisMonth());
+        assertEquals("${ENVVAL_OF_THIS_YEAR}", versionNumberBuilder.getBuildsThisYear());
+        
+    }
+    
+    public void testThatOverrideValuesGetResetAfterJobRuns() throws Exception {
+        FreeStyleProject job = createFreeStyleProject("versionNumberJob");
+        VersionNumberBuilder versionNumberBuilder = new VersionNumberBuilder(
+                "${BUILDS_TODAY}.${BUILDS_THIS_WEEK}.${BUILDS_THIS_MONTH}.${BUILDS_THIS_YEAR}.${BUILDS_ALL_TIME}",
+                null, null, null, "1", "7", "30", "365", "500", false, true);
+        
+        EnvironmentVariablesNodeProperty prop = new EnvironmentVariablesNodeProperty();
+        EnvVars envVars = prop.getEnvVars();
+        super.hudson.getGlobalNodeProperties().add(prop);
+        
+        job.getBuildWrappersList().add(versionNumberBuilder);
+        FreeStyleBuild build = buildAndAssertSuccess(job);
+        assertEquals("1.7.30.365.500", build.getDisplayName());
+        
+        // make sure that the direct set variables were cleaned up
+        assertEquals("", versionNumberBuilder.getBuildsAllTime());
+        assertEquals("", versionNumberBuilder.getBuildsToday());
+        assertEquals("", versionNumberBuilder.getBuildsThisWeek());
+        assertEquals("", versionNumberBuilder.getBuildsThisMonth());
+        assertEquals("", versionNumberBuilder.getBuildsThisYear());
     }
     
     private void assertBuildsAllTime(int expected, AbstractBuild build) {

--- a/src/test/java/org/jvnet/hudson/tools/versionnumber/VersionNumberStepTest.java
+++ b/src/test/java/org/jvnet/hudson/tools/versionnumber/VersionNumberStepTest.java
@@ -122,4 +122,61 @@ public class VersionNumberStepTest {
 			}
 		});
 	}
+	
+	@Test
+	public void BuildsAllTimeFromEnvironmentVariable() {
+		story.addStep(new Statement() {
+			@Override
+			public void evaluate() throws Throwable {
+				WorkflowJob p = story.j.jenkins.createProject(WorkflowJob.class, "p");
+				p.setDefinition(new CpsFlowDefinition(
+				        "withEnv(['NEXT_BUILD_NUMBER=5']) {\n" +
+						"def versionNumber = VersionNumber versionNumberString: '${BUILDS_ALL_TIME}', versionPrefix: '1.0.', buildsAllTime: '${NEXT_BUILD_NUMBER}'\n" +
+						"   echo \"VersionNumber: ${versionNumber}\"\n" +
+                        "}"
+				));
+				WorkflowRun b1 = p.scheduleBuild2(0).waitForStart();
+				story.j.waitForCompletion(b1);
+				story.j.assertBuildStatus(Result.SUCCESS, b1);
+				story.j.assertLogContains("VersionNumber: 1.0.5", b1);
+			}
+		});
+	}
+
+	@Test
+	public void BuildsAllTimeFromEnvironmentVariableThatIsMissing() {
+		story.addStep(new Statement() {
+			@Override
+			public void evaluate() throws Throwable {
+				WorkflowJob p = story.j.jenkins.createProject(WorkflowJob.class, "p");
+				p.setDefinition(new CpsFlowDefinition(
+						"def versionNumber = VersionNumber versionNumberString: '${BUILDS_ALL_TIME}', versionPrefix: '1.0.', buildsAllTime: '${NEXT_BUILD_NUMBER}'\n" +
+						"   echo \"VersionNumber: ${versionNumber}\"\n"
+				));
+				WorkflowRun b1 = p.scheduleBuild2(0).waitForStart();
+				story.j.waitForCompletion(b1);
+				story.j.assertBuildStatus(Result.SUCCESS, b1);
+				story.j.assertLogContains("VersionNumber: 1.0.1", b1);
+			}
+		});
+	}
+	
+	@Test
+	public void BuildsAllTimeFromDirectOverride() {
+		story.addStep(new Statement() {
+			@Override
+			public void evaluate() throws Throwable {
+				WorkflowJob p = story.j.jenkins.createProject(WorkflowJob.class, "p");
+				p.setDefinition(new CpsFlowDefinition(
+						"def versionNumber = VersionNumber versionNumberString: '${BUILDS_ALL_TIME}', versionPrefix: '1.0.', buildsAllTime: '12'\n" +
+						"   echo \"VersionNumber: ${versionNumber}\"\n"
+				));
+				WorkflowRun b1 = p.scheduleBuild2(0).waitForStart();
+				story.j.waitForCompletion(b1);
+				story.j.assertBuildStatus(Result.SUCCESS, b1);
+				story.j.assertLogContains("VersionNumber: 1.0.12", b1);
+			}
+		});
+	}
+	
 }

--- a/src/test/java/org/jvnet/hudson/tools/versionnumber/VersionNumberStepTest.java
+++ b/src/test/java/org/jvnet/hudson/tools/versionnumber/VersionNumberStepTest.java
@@ -1,26 +1,18 @@
 package org.jvnet.hudson.tools.versionnumber;
 
-import java.io.IOException;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 
 import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
-import org.jenkinsci.plugins.workflow.test.steps.SemaphoreStep;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runners.model.Statement;
 import org.jvnet.hudson.test.BuildWatcher;
 import org.jvnet.hudson.test.RestartableJenkinsRule;
-import org.jvnet.hudson.test.TestBuilder;
 
-import hudson.Launcher;
-import hudson.model.AbstractBuild;
-import hudson.model.BuildListener;
-import hudson.model.FreeStyleBuild;
-import hudson.model.FreeStyleProject;
 import hudson.model.Result;
 
 public class VersionNumberStepTest {
@@ -58,6 +50,90 @@ public class VersionNumberStepTest {
 				story.j.assertLogContains("VersionNumber: " + todayDate + "-03", b3);
 			}
 		});
+	}
+	
+	@Test
+	public void SkipFailedBuildsTrue() {
+		story.addStep(new Statement() {
+			@Override
+			public void evaluate() throws Throwable {
+				String todayDate = new SimpleDateFormat("yy-MM-dd").format(new Date());
+				WorkflowJob p = story.j.jenkins.createProject(WorkflowJob.class, "p");
+				p.setDefinition(new CpsFlowDefinition(
+						"def versionNumber = VersionNumber skipFailedBuilds: true, versionNumberString: '${BUILD_DATE_FORMATTED, \"yy-MM-dd\"}-${BUILDS_TODAY, XX}'\n" +
+						"echo \"VersionNumber: ${versionNumber}\""
+				));
+				WorkflowRun b1 = p.scheduleBuild2(0).waitForStart();
+				story.j.waitForCompletion(b1);
+				story.j.assertBuildStatus(Result.SUCCESS, b1);
+				story.j.assertLogContains("VersionNumber: " + todayDate + "-01", b1);
+
+				// Force a failure!
+				p.setDefinition(new CpsFlowDefinition(
+						"def versionNumber = VersionNumber skipFailedBuilds: true, versionNumberString: '${BUILD_DATE_FORMATTED, \"yy-MM-dd\"}-${BUILDS_TODAY, XX}'\n" +
+						"throw new RuntimeException(\"Fail!\")"
+				));
+				
+				WorkflowRun b2 = p.scheduleBuild2(0).waitForStart();
+				story.j.waitForCompletion(b2);
+				story.j.assertBuildStatus(Result.FAILURE, b2);
+
+				// Restore the working job
+				p.setDefinition(new CpsFlowDefinition(
+						"def versionNumber = VersionNumber skipFailedBuilds: true, versionNumberString: '${BUILD_DATE_FORMATTED, \"yy-MM-dd\"}-${BUILDS_TODAY, XX}'\n" +
+						"echo \"VersionNumber: ${versionNumber}\""
+				));
+				
+				// Make sure we didn't increment!
+				WorkflowRun b3 = p.scheduleBuild2(0).waitForStart();
+				story.j.waitForCompletion(b3);
+				story.j.assertBuildStatus(Result.SUCCESS, b3);
+				story.j.assertLogContains("VersionNumber: " + todayDate + "-02", b3);
+			}
+		});
+		
+	}
+	
+	@Test
+	public void SkipFailedBuildsFalse() {
+		story.addStep(new Statement() {
+			@Override
+			public void evaluate() throws Throwable {
+				String todayDate = new SimpleDateFormat("yy-MM-dd").format(new Date());
+				WorkflowJob p = story.j.jenkins.createProject(WorkflowJob.class, "p");
+				p.setDefinition(new CpsFlowDefinition(
+						"def versionNumber = VersionNumber skipFailedBuilds: false, versionNumberString: '${BUILD_DATE_FORMATTED, \"yy-MM-dd\"}-${BUILDS_TODAY, XX}'\n" +
+						"echo \"VersionNumber: ${versionNumber}\""
+				));
+				WorkflowRun b1 = p.scheduleBuild2(0).waitForStart();
+				story.j.waitForCompletion(b1);
+				story.j.assertBuildStatus(Result.SUCCESS, b1);
+				story.j.assertLogContains("VersionNumber: " + todayDate + "-01", b1);
+
+				// Force a failure!
+				p.setDefinition(new CpsFlowDefinition(
+						"def versionNumber = VersionNumber skipFailedBuilds: false, versionNumberString: '${BUILD_DATE_FORMATTED, \"yy-MM-dd\"}-${BUILDS_TODAY, XX}'\n" +
+						"throw new RuntimeException(\"Fail!\")"
+				));
+				
+				WorkflowRun b2 = p.scheduleBuild2(0).waitForStart();
+				story.j.waitForCompletion(b2);
+				story.j.assertBuildStatus(Result.FAILURE, b2);
+
+				// Restore the working job
+				p.setDefinition(new CpsFlowDefinition(
+						"def versionNumber = VersionNumber skipFailedBuilds: false, versionNumberString: '${BUILD_DATE_FORMATTED, \"yy-MM-dd\"}-${BUILDS_TODAY, XX}'\n" +
+						"echo \"VersionNumber: ${versionNumber}\""
+				));
+				
+				// Make sure that we incremented anyhow!
+				WorkflowRun b3 = p.scheduleBuild2(0).waitForStart();
+				story.j.waitForCompletion(b3);
+				story.j.assertBuildStatus(Result.SUCCESS, b3);
+				story.j.assertLogContains("VersionNumber: " + todayDate + "-03", b3);
+			}
+		});
+		
 	}
 	
 	@Test
@@ -131,7 +207,7 @@ public class VersionNumberStepTest {
 				WorkflowJob p = story.j.jenkins.createProject(WorkflowJob.class, "p");
 				p.setDefinition(new CpsFlowDefinition(
 				        "withEnv(['NEXT_BUILD_NUMBER=5']) {\n" +
-						"def versionNumber = VersionNumber versionNumberString: '${BUILDS_ALL_TIME}', versionPrefix: '1.0.', buildsAllTime: '${NEXT_BUILD_NUMBER}'\n" +
+						"def versionNumber = VersionNumber versionNumberString: '${BUILDS_ALL_TIME}', versionPrefix: '1.0.', overrideBuildsAllTime: '${NEXT_BUILD_NUMBER}'\n" +
 						"   echo \"VersionNumber: ${versionNumber}\"\n" +
                         "}"
 				));
@@ -150,7 +226,7 @@ public class VersionNumberStepTest {
 			public void evaluate() throws Throwable {
 				WorkflowJob p = story.j.jenkins.createProject(WorkflowJob.class, "p");
 				p.setDefinition(new CpsFlowDefinition(
-						"def versionNumber = VersionNumber versionNumberString: '${BUILDS_ALL_TIME}', versionPrefix: '1.0.', buildsAllTime: '${NEXT_BUILD_NUMBER}'\n" +
+						"def versionNumber = VersionNumber versionNumberString: '${BUILDS_ALL_TIME}', versionPrefix: '1.0.', overrideBuildsAllTime: '${NEXT_BUILD_NUMBER}'\n" +
 						"   echo \"VersionNumber: ${versionNumber}\"\n"
 				));
 				WorkflowRun b1 = p.scheduleBuild2(0).waitForStart();
@@ -168,7 +244,79 @@ public class VersionNumberStepTest {
 			public void evaluate() throws Throwable {
 				WorkflowJob p = story.j.jenkins.createProject(WorkflowJob.class, "p");
 				p.setDefinition(new CpsFlowDefinition(
-						"def versionNumber = VersionNumber versionNumberString: '${BUILDS_ALL_TIME}', versionPrefix: '1.0.', buildsAllTime: '12'\n" +
+						"def versionNumber = VersionNumber versionNumberString: '${BUILDS_ALL_TIME}', versionPrefix: '1.0.', overrideBuildsAllTime: '12'\n" +
+						"   echo \"VersionNumber: ${versionNumber}\"\n"
+				));
+				WorkflowRun b1 = p.scheduleBuild2(0).waitForStart();
+				story.j.waitForCompletion(b1);
+				story.j.assertBuildStatus(Result.SUCCESS, b1);
+				story.j.assertLogContains("VersionNumber: 1.0.12", b1);
+			}
+		});
+	}
+
+	@Test
+	public void BuildsTodayFromDirectOverride() {
+		story.addStep(new Statement() {
+			@Override
+			public void evaluate() throws Throwable {
+				WorkflowJob p = story.j.jenkins.createProject(WorkflowJob.class, "p");
+				p.setDefinition(new CpsFlowDefinition(
+						"def versionNumber = VersionNumber versionNumberString: '${BUILDS_TODAY}', versionPrefix: '1.0.', overrideBuildsToday: '12'\n" +
+						"   echo \"VersionNumber: ${versionNumber}\"\n"
+				));
+				WorkflowRun b1 = p.scheduleBuild2(0).waitForStart();
+				story.j.waitForCompletion(b1);
+				story.j.assertBuildStatus(Result.SUCCESS, b1);
+				story.j.assertLogContains("VersionNumber: 1.0.12", b1);
+			}
+		});
+	}
+
+	@Test
+	public void BuildsThisWeekFromDirectOverride() {
+		story.addStep(new Statement() {
+			@Override
+			public void evaluate() throws Throwable {
+				WorkflowJob p = story.j.jenkins.createProject(WorkflowJob.class, "p");
+				p.setDefinition(new CpsFlowDefinition(
+						"def versionNumber = VersionNumber versionNumberString: '${BUILDS_THIS_WEEK}', versionPrefix: '1.0.', overrideBuildsThisWeek: '12'\n" +
+						"   echo \"VersionNumber: ${versionNumber}\"\n"
+				));
+				WorkflowRun b1 = p.scheduleBuild2(0).waitForStart();
+				story.j.waitForCompletion(b1);
+				story.j.assertBuildStatus(Result.SUCCESS, b1);
+				story.j.assertLogContains("VersionNumber: 1.0.12", b1);
+			}
+		});
+	}
+	
+	@Test
+	public void BuildsThisMonthFromDirectOverride() {
+		story.addStep(new Statement() {
+			@Override
+			public void evaluate() throws Throwable {
+				WorkflowJob p = story.j.jenkins.createProject(WorkflowJob.class, "p");
+				p.setDefinition(new CpsFlowDefinition(
+						"def versionNumber = VersionNumber versionNumberString: '${BUILDS_THIS_MONTH}', versionPrefix: '1.0.', overrideBuildsThisMonth: '12'\n" +
+						"   echo \"VersionNumber: ${versionNumber}\"\n"
+				));
+				WorkflowRun b1 = p.scheduleBuild2(0).waitForStart();
+				story.j.waitForCompletion(b1);
+				story.j.assertBuildStatus(Result.SUCCESS, b1);
+				story.j.assertLogContains("VersionNumber: 1.0.12", b1);
+			}
+		});
+	}
+
+	@Test
+	public void BuildsThisYearFromDirectOverride() {
+		story.addStep(new Statement() {
+			@Override
+			public void evaluate() throws Throwable {
+				WorkflowJob p = story.j.jenkins.createProject(WorkflowJob.class, "p");
+				p.setDefinition(new CpsFlowDefinition(
+						"def versionNumber = VersionNumber versionNumberString: '${BUILDS_THIS_YEAR}', versionPrefix: '1.0.', overrideBuildsThisYear: '12'\n" +
 						"   echo \"VersionNumber: ${versionNumber}\"\n"
 				));
 				WorkflowRun b1 = p.scheduleBuild2(0).waitForStart();


### PR DESCRIPTION
Added support to override BUILDS_ALL_TIME via pipeline in the same manner as supported by the existing freestyle job.  Tests are included.

See discussion on https://github.com/jenkinsci/versionnumber-plugin/pull/14 for some background on the request.

Here are examples, one uses a direct version override, the other an environment variable.

```
def versionNumber = VersionNumber versionNumberString: '${BUILDS_ALL_TIME}', versionPrefix: '1.0.', buildsAllTime: '12'
echo "VersionNumber: ${versionNumber}"
```
or like this:
```
withEnv(['NEXT_BUILD_NUMBER=5']) {
    def versionNumber = VersionNumber versionNumberString: '${BUILDS_ALL_TIME}', versionPrefix: '1.0.', buildsAllTime: '${NEXT_BUILD_NUMBER}'
    echo "VersionNumber: ${versionNumber}"
}
```