### PR TITLE
Fix javadoc error

### DIFF
--- a/src/main/java/org/jvnet/hudson/tools/versionnumber/VersionNumberBuilder.java
+++ b/src/main/java/org/jvnet/hudson/tools/versionnumber/VersionNumberBuilder.java
@@ -188,7 +188,7 @@ public class VersionNumberBuilder extends BuildWrapper {
     }
         
     /**
-     * We'll use this from the <tt>config.jelly</tt>.
+     * We'll use this from the <code>config.jelly</code>.
      */
     public String getVersionNumberString() {
         return versionNumberString;


### PR DESCRIPTION
## Fix javadoc error

Javadoc no longer allows the `tt` tag.  Use `code` instead.

- [x]Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
