### PR TITLE
Increase spotbugs checks

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,8 @@
   <packaging>hpi</packaging>
 
   <properties>
-    
+    <spotbugs.effort>Max</spotbugs.effort>
+    <spotbugs.failOnError>true</spotbugs.failOnError>
     <jenkins.version>2.332.4</jenkins.version>
   </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -15,6 +15,7 @@
 
   <properties>
     <spotbugs.effort>Max</spotbugs.effort>
+    <spotbugs.threshold>Low</spotbugs.threshold>
     <jenkins.version>2.332.4</jenkins.version>
   </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,6 @@
 
   <properties>
     <spotbugs.effort>Max</spotbugs.effort>
-    <spotbugs.failOnError>true</spotbugs.failOnError>
     <jenkins.version>2.332.4</jenkins.version>
   </properties>
 

--- a/src/main/java/org/jvnet/hudson/tools/versionnumber/VersionNumberBuilder.java
+++ b/src/main/java/org/jvnet/hudson/tools/versionnumber/VersionNumberBuilder.java
@@ -224,15 +224,6 @@ public class VersionNumberBuilder extends BuildWrapper {
         return VersionNumberCommon.getPreviousBuildWithVersionNumber(build, envPrefix);
     }
     
-    private boolean isOverrideString(String override) {
-        boolean result = false;
-        
-        if (override != null && !override.equals("")) {
-            result = true;
-        }
-        return result;
-    }
-    
     @SuppressWarnings("unchecked")
     private VersionNumberBuildInfo incBuild(Run build, BuildListener listener) throws IOException, InterruptedException {
         EnvVars enVars = build.getEnvironment(listener);

--- a/src/spotbugs/excludesFilter.xml
+++ b/src/spotbugs/excludesFilter.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FindBugsFilter>
+  <!--
+    Exclusions in this section have been triaged and determined to be false positives.
+  -->
+
+  <!--
+    Here lies technical debt. Exclusions in this section have not yet been triaged. When working on
+    on this section, pick an exclusion to triage, then:
+    - If it is a false positive, add a @SuppressFBWarnings(value = "[…]", justification = "[…]")
+      annotation indicating the reason why it is a false positive, then remove the exclusion from
+      this section.
+    - If it is not a false positive, fix the bug, then remove the exclusion from this section.
+   -->
+  <Match>
+    <Bug pattern="SE_TRANSIENT_FIELD_NOT_RESTORED"/>
+    <Class name="org.jvnet.hudson.tools.versionnumber.VersionNumberStep$Execution"/>
+    <Field name="env"/>
+  </Match>
+  <Match>
+    <Bug pattern="REC_CATCH_EXCEPTION"/>
+    <Class name="org.jvnet.hudson.tools.versionnumber.AbstractBuildNumberGenerator"/>
+    <Method name="resolveOverride"/>
+  </Match>
+  <Match>
+    <Bug pattern="REC_CATCH_EXCEPTION"/>
+    <Class name="org.jvnet.hudson.tools.versionnumber.VersionNumberStep$Execution"/>
+    <Method name="run"/>
+  </Match>
+</FindBugsFilter>


### PR DESCRIPTION
## Enable deeper spotbugs checks

- Enable more Spotbugs checks
- Do not need default spotbugs.failOnError value
- Remove uncalled private method
- Check spotbugs warnings more deeply

Spotbugs checks will be applied to future pull requests to avoid creating issues that spotbugs static analysis could have detected.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
