### PR TITLE
Show docs on plugins site

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,9 @@
 
   <name>Version Number Plugin</name>
   <description>Jenkins plugin which generates formatted version numbers for build jobs.</description>
-  <url>https://github.com/jenkinsci/versionnumber-plugin</url>
+  <!-- Docs were not being published to plugins site with shorter URL -->
+  <!-- Use the precise location of the documentation page -->
+  <url>https://github.com/jenkinsci/versionnumber-plugin/blob/master/README.adoc</url>
 
   <licenses>
     <license>


### PR DESCRIPTION
## Show plugins docs on plugins.jenkins.io

Plugin documentation is not displayed at https://plugins.jenkins.io/versionnumber/ for this plugin even though the documentation is in the repository.

### Testing done

No testing done

### Submitter checklist

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
