### PR TITLE
Build on container agents

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,7 @@
 #!/usr/bin/groovy
 
 buildPlugin(failFast: false,
+            useContainerAgent: true,
             configurations: [
                 [platform: 'linux',   jdk: '17'],
                 [platform: 'linux',   jdk: '11']


### PR DESCRIPTION
Container agents are usually faster to provision than a VM.