### PR TITLE
Require Jenkins 2.479.1, Java 17, and Jakarta EE 9

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,32 +37,6 @@
     </license>
   </licenses>
 
-  <developers>
-    <developer>
-      <id>bahadir</id>
-      <name>Deniz Bahadir</name>
-      <email>versionnumber-plugin.jenkins@deniz.bahadir.email</email>
-      <timezone>Europe/Berlin</timezone>
-    </developer>
-    <developer>
-      <id>rosberglinhares</id>
-      <name>Rosberg Linhares</name>
-      <email>rosberglinhares@gmail.com</email>
-      <timezone>America/Recife</timezone>
-    </developer>
-    <developer>
-      <id>abayer</id>
-      <name>Andrew Bayer</name>
-      <email>andrew.bayer@gmail.com</email>
-      <timezone>-8</timezone>
-    </developer>
-    <developer>
-      <id>cchabanois</id>
-      <name>Cedric Chabanois</name>
-      <email>cchabanois@gmail.com</email>
-    </developer>
-  </developers>
-
   <scm>
     <connection>scm:git:https://github.com/${gitHubRepo}.git</connection>
     <developerConnection>scm:git:git@github.com:${gitHubRepo}.git</developerConnection>

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,6 @@
   </properties>
 
   <name>Version Number Plugin</name>
-  <description>Jenkins plugin which generates formatted version numbers for build jobs.</description>
   <!-- Docs were not being published to plugins site with shorter URL -->
   <!-- Use the precise location of the documentation page -->
   <url>https://github.com/jenkinsci/versionnumber-plugin/blob/master/README.adoc</url>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>4.88</version>
+    <version>5.7</version>
     <relativePath />
   </parent>
   <groupId>org.jvnet.hudson.tools</groupId>
@@ -20,8 +20,8 @@
     <changelist>-SNAPSHOT</changelist>
     <gitHubRepo>jenkinsci/versionnumber-plugin</gitHubRepo>
     <!-- https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/ -->
-    <jenkins.baseline>2.452</jenkins.baseline>
-    <jenkins.version>${jenkins.baseline}.4</jenkins.version>
+    <jenkins.baseline>2.479</jenkins.baseline>
+    <jenkins.version>${jenkins.baseline}.3</jenkins.version>
   </properties>
 
   <name>Version Number Plugin</name>
@@ -62,7 +62,7 @@
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
         <artifactId>bom-${jenkins.baseline}.x</artifactId>
-        <version>3944.v1a_e4f8b_452db_</version>
+        <version>4136.vca_c3202a_7fd1</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/src/main/java/org/jvnet/hudson/tools/versionnumber/VersionNumberBuilder.java
+++ b/src/main/java/org/jvnet/hudson/tools/versionnumber/VersionNumberBuilder.java
@@ -12,7 +12,7 @@ import java.lang.invoke.MethodHandles;
 
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.QueryParameter;
-import org.kohsuke.stapler.StaplerRequest;
+import org.kohsuke.stapler.StaplerRequest2;
 
 import hudson.EnvVars;
 import hudson.Extension;
@@ -420,7 +420,7 @@ public class VersionNumberBuilder extends BuildWrapper {
         }
         
         @Override
-        public boolean configure(StaplerRequest req, JSONObject json) throws FormException {
+        public boolean configure(StaplerRequest2 req, JSONObject json) throws FormException {
             return super.configure(req, json);
         }
         


### PR DESCRIPTION
## Require Jenkins 2.479.1, Java 17, and Jakarta EE 9

Require Jenkins 2.479.1, Java 17, and Jakarta EE 9

Replaces:

* https://github.com/jenkinsci/versionnumber-plugin/pull/89

- Remove the unused description property from pom file
- Remove unused developers section from pom

### Testing done

Automated tests pass.  Confirmed that no other plugins depend on this plugin.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
